### PR TITLE
Adding support for titlepage images

### DIFF
--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -15,7 +15,7 @@ fs.readFile(file, function editContent (err, contents) {
   	header = '<h1 class="ChapTitleNonprintingctnp">Title Page</h1>';
   	$('section[data-type="titlepage"]').prepend(header);
   	//add image holder
-  	image = '<img src="epubtitlepage.jpg"/>';
+  	image = '<img width="100%" src="epubtitlepage.jpg"/>';
   	$('section[data-type="titlepage"]').append(image);
   }
 

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -10,13 +10,13 @@ fs.readFile(file, function editContent (err, contents) {
 // add titlepage image if applicable
   if ($('section[data-titlepage="yes"]').length) {
   	//remove content
-  	$('section[data-type="titlepage"').empty();
+  	$('section[data-type="titlepage"]').empty();
   	//add header back in w nonprinting class
   	header = '<h1 class="Nonprinting">Title Page</h1>';
-  	$('section[data-type="titlepage"').prepend(header);
+  	$('section[data-type="titlepage"]').prepend(header);
   	//add image holder
   	image = '<img src="ebooktitlepage.jpg"/>';
-  	$('section[data-type="titlepage"').append(image);
+  	$('section[data-type="titlepage"]').append(image);
   }
 
   var output = $.html();

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -15,7 +15,7 @@ fs.readFile(file, function editContent (err, contents) {
   	header = '<h1 class="Nonprinting">Title Page</h1>';
   	$('section[data-type="titlepage"]').prepend(header);
   	//add image holder
-  	image = '<img src="ebooktitlepage.jpg"/>';
+  	image = '<img src="epubtitlepage.jpg"/>';
   	$('section[data-type="titlepage"]').append(image);
   }
 

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -12,7 +12,7 @@ fs.readFile(file, function editContent (err, contents) {
   	//remove content
   	$('section[data-type="titlepage"]').empty();
   	//add header back in w nonprinting class
-  	header = '<h1 class="Nonprinting">Title Page</h1>';
+  	header = '<h1 class="ChapTitleNonprintingctnp">Title Page</h1>';
   	$('section[data-type="titlepage"]').prepend(header);
   	//add image holder
   	image = '<img src="epubtitlepage.jpg"/>';

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -1,0 +1,30 @@
+var fs = require('fs');
+var cheerio = require('cheerio');
+var file = process.argv[2];
+
+fs.readFile(file, function editContent (err, contents) {
+  $ = cheerio.load(contents, {
+          xmlMode: true
+        });
+
+// add titlepage image if applicable
+  if ($('section[data-titlepage="yes"]').length) {
+  	//remove content
+  	$('section[data-type="titlepage"').empty();
+  	//add header back in w nonprinting class
+  	header = '<h1 class="Nonprinting">Title Page</h1>';
+  	$('section[data-type="titlepage"').prepend(header);
+  	//add image holder
+  	image = '<img src="ebooktitlepage.jpg"/>';
+  	$('section[data-type="titlepage"').append(image);
+  }
+
+  var output = $.html();
+	  fs.writeFile(file, output, function(err) {
+	    if(err) {
+	        return console.log(err);
+	    }
+
+	    console.log("Content has been updated!");
+	});
+});

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -58,6 +58,7 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
+puts imgstring
 etpfilename = imgstring.match(/(epubtitlepage.*?)(,)/)[1]
 etpfiletype = etpfilename.split(".").pop
 epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -60,7 +60,7 @@ finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
 etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*?/)
 
-if etpfilename?
+unless etpfilename.nil?
   epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
   puts epubtitlepage
   epubtitlepagearc = File.join(finalimagedir, etpfilename)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -59,6 +59,7 @@ images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
 etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*/).to_s
+puts etpfilename
 
 unless etpfilename.nil?
   epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -58,6 +58,7 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
+puts imgstring
 etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*/).to_s
 puts etpfilename
 

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -58,7 +58,7 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
-etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*?/)
+etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*/).to_s
 puts etpfilename
 
 unless etpfilename.nil?

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -59,7 +59,7 @@ images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
 puts imgstring
-etpfilename = imgstring.match(/(epubtitlepage.*?)(,)/)[1]
+etpfilename = imgstring.match(/(epubtitlepage.*?)(,?)/)[1]
 etpfiletype = etpfilename.split(".").pop
 epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
 epubtitlepagearc = File.join(finalimagedir, etpfilename)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -62,12 +62,10 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
-puts imgstring
 etpfilenamearr = imgstring.match(/epubtitlepage.[a-zA-Z]*/)
-etpfilename = etpfilenamearr
-puts etpfilename
+etpfilename = etpfilenamearr.to_s
 
-unless etpfilename.nil?
+unless etpfilenamearr.nil?
   epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
   epubtitlepagearc = File.join(finalimagedir, etpfilename)
   epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -66,7 +66,7 @@ epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
 
 if File.file?(epubtitlepage)
   filecontents = filecontents.gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
-  unless etpfiletype = "jpg"
+  unless etpfiletype == "jpg"
     `convert "#{epubtitlepage}" "#{epubtitlepagejpg}"`
   end
   FileUtils.mv(epubtitlepagejpg, finalimagedir)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -67,6 +67,7 @@ unless etpfilename.nil?
   epubtitlepagearc = File.join(finalimagedir, etpfilename)
   epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
   etpfiletype = etpfilename.split(".").pop
+  puts etpfiletype
   filecontents = filecontents.gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   unless etpfiletype == "jpg"
     `convert "#{epubtitlepage}" "#{epubtitlepagejpg}"`

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -59,15 +59,12 @@ images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
 etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*/).to_s
-puts etpfilename
 
 unless etpfilename.nil?
   epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
-  puts epubtitlepage
   epubtitlepagearc = File.join(finalimagedir, etpfilename)
   epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
   etpfiletype = etpfilename.split(".").pop
-  puts etpfiletype
   filecontents = filecontents.gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   unless etpfiletype == "jpg"
     `convert "#{epubtitlepage}" "#{epubtitlepagejpg}"`

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -59,6 +59,7 @@ images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
 etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*?/)
+puts etpfilename
 
 unless etpfilename.nil?
   epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -70,9 +70,9 @@ unless etpfilename.nil?
   filecontents = filecontents.gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   unless etpfiletype == "jpg"
     `convert "#{epubtitlepage}" "#{epubtitlepagejpg}"`
+    FileUtils.mv(epubtitlepage, epubtitlepagearc)
   end
   FileUtils.mv(epubtitlepagejpg, finalimagedir)
-  FileUtils.mv(epubtitlepage, epubtitlepagearc)
 end
 
 File.open(epub_tmp_html, 'w') do |output| 

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -58,14 +58,14 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
-puts imgstring
-etpfilename = imgstring.match(/(epubtitlepage.*?)(,?)/)[1]
-etpfiletype = etpfilename.split(".").pop
-epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
-epubtitlepagearc = File.join(finalimagedir, etpfilename)
-epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
+etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*?/)
 
-if File.file?(epubtitlepage)
+if etpfilename?
+  epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
+  puts epubtitlepage
+  epubtitlepagearc = File.join(finalimagedir, etpfilename)
+  epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
+  etpfiletype = etpfilename.split(".").pop
   filecontents = filecontents.gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   unless etpfiletype == "jpg"
     `convert "#{epubtitlepage}" "#{epubtitlepagejpg}"`

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -59,7 +59,8 @@ images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 imgstring = images.join(",")
 puts imgstring
-etpfilename = imgstring.match(/epubtitlepage.[a-zA-Z]*/).to_s
+etpfilenamearr = imgstring.match(/epubtitlepage.[a-zA-Z]*/)
+etpfilename = etpfilenamearr
 puts etpfilename
 
 unless etpfilename.nil?


### PR DESCRIPTION
Users can insert a titlepage image instead of the textual titlepage. Image files must be called "epubtitlepage.foo".