### PR TITLE
Adding support for titlepage images

### DIFF
--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -69,8 +69,10 @@ if etparr.any?
 elsif ptparr.any?
   epubtitlepage = ptparr.find { |e| /(\/?\\?)+titlepage\./ =~ e }
 end
+puts epubtitlepage
 
 unless epubtitlepage.nil?
+  puts "found a titlepage"
   etpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   epubtitlepagearc = File.join(finalimagedir, etpfilename)
   epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -68,9 +68,9 @@ puts etparr
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
 puts ptparr
 if etparr.any?
-  epubtitlepage = etparr.find { |e| /(\/?\\?)+epubtitlepage\./ =~ e }
+  epubtitlepage = etparr.find { |e| /[\/|\\]epubtitlepage\./ =~ e }
 elsif ptparr.any?
-  epubtitlepage = ptparr.find { |e| /(\/?\\?)+titlepage\./ =~ e }
+  epubtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
 end
 puts epubtitlepage
 

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -59,26 +59,21 @@ end
 # convert image to jpg
 # copy to image dir
 
-images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
-allimg = File.join(Bkmkr::Paths.submitted_images, "*")
-puts allimg
+allimg = File.join(finalimagedir, "*")
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
-puts etparr
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
-puts ptparr
 if etparr.any?
   epubtitlepage = etparr.find { |e| /[\/|\\]epubtitlepage\./ =~ e }
 elsif ptparr.any?
   epubtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
 end
-puts epubtitlepage
 
 unless epubtitlepage.nil?
-  puts "found a titlepage"
+  puts "found an epub titlepage image"
   etpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   epubtitlepagearc = File.join(finalimagedir, etpfilename)
-  epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
+  epubtitlepagejpg = File.join(finalimagedir, "epubtitlepage.jpg")
   etpfiletype = etpfilename.split(".").pop
   filecontents = File.read(epub_tmp_html).gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   File.open(epub_tmp_html, 'w') do |output| 
@@ -86,9 +81,7 @@ unless epubtitlepage.nil?
   end
   unless etpfiletype == "jpg"
     `convert "#{epubtitlepage}" "#{epubtitlepagejpg}"`
-    FileUtils.mv(epubtitlepage, epubtitlepagearc)
   end
-  FileUtils.mv(epubtitlepagejpg, finalimagedir)
   # insert titlepage image
   epubmakerpreprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "epubmaker_preprocessing.js")
   Bkmkr::Tools.runnode(epubmakerpreprocessingjs, epub_tmp_html)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -61,12 +61,17 @@ end
 
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
-imgstring = images.join(",")
-etpfilenamearr = imgstring.match(/epubtitlepage.[a-zA-Z]*/)
-etpfilename = etpfilenamearr.to_s
+allimg = File.join(images, "*")
+etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
+ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
+if etparr.any?
+  epubtitlepage = etparr.find { |e| /(\/?\\?)+epubtitlepage\./ =~ e }
+elsif ptparr.any?
+  epubtitlepage = ptparr.find { |e| /(\/?\\?)+titlepage\./ =~ e }
+end
 
-unless etpfilenamearr.nil?
-  epubtitlepage = File.join(Bkmkr::Paths.submitted_images, etpfilename)
+unless epubtitlepage.nil?
+  etpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   epubtitlepagearc = File.join(finalimagedir, etpfilename)
   epubtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "epubtitlepage.jpg")
   etpfiletype = etpfilename.split(".").pop

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -15,6 +15,7 @@ epub_tmp_html = File.join(Bkmkr::Paths.project_tmp_dir, "epub_tmp.html")
 saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{Bkmkr::Tools.xslprocessor}.jar")
 assets_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "epubmaker")
 epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
+finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 
 unless File.exist?(epub_img_dir)
     Dir.mkdir(epub_img_dir)

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -62,8 +62,11 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 allimg = File.join(images, "*")
+puts allimg
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
+puts etparr
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
+puts ptparr
 if etparr.any?
   epubtitlepage = etparr.find { |e| /(\/?\\?)+epubtitlepage\./ =~ e }
 elsif ptparr.any?

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -61,7 +61,7 @@ end
 
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
-allimg = File.join(images, "*")
+allimg = File.join(Bkmkr::Paths.submitted_images, "*")
 puts allimg
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
 puts etparr

--- a/filearchive_preprocessing.rb
+++ b/filearchive_preprocessing.rb
@@ -1,0 +1,32 @@
+require 'fileutils'
+
+require_relative '../bookmaker/core/header.rb'
+require_relative '../bookmaker/core/metadata.rb'
+
+# These commands should run immediately prior to filearchive
+
+# Find supplemental titlepages
+images = Dir.entries(Bkmkr::Paths.submitted_images)
+finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
+allimg = File.join(Bkmkr::Paths.submitted_images, "*")
+etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
+ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
+if etparr.any?
+  epubtitlepage = etparr.find { |e| /[\/|\\]epubtitlepage\./ =~ e }
+end
+
+if ptparr.any?
+  podtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
+end
+
+if File.file?(epubtitlepage)
+	etpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+	epubtitlepagearc = File.join(finalimagedir, etpfilename)
+	FileUtils.mv(epubtitlepage, epubtitlepagearc)
+end
+
+if File.file?(podtitlepage)
+	ptpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+	podtitlepagearc = File.join(finalimagedir, ptpfilename)
+	FileUtils.mv(podtitlepage, podtitlepagearc)
+end

--- a/filearchive_preprocessing.rb
+++ b/filearchive_preprocessing.rb
@@ -19,13 +19,13 @@ if ptparr.any?
   podtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
 end
 
-if File.file?(epubtitlepage)
+unless epubtitlepage.nil?
 	etpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
 	epubtitlepagearc = File.join(finalimagedir, etpfilename)
 	FileUtils.mv(epubtitlepage, epubtitlepagearc)
 end
 
-if File.file?(podtitlepage)
+unless podtitlepage.nil?
 	ptpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
 	podtitlepagearc = File.join(finalimagedir, ptpfilename)
 	FileUtils.mv(podtitlepage, podtitlepagearc)

--- a/filearchive_preprocessing.rb
+++ b/filearchive_preprocessing.rb
@@ -6,27 +6,16 @@ require_relative '../bookmaker/core/metadata.rb'
 # These commands should run immediately prior to filearchive
 
 # Find supplemental titlepages
-images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
-allimg = File.join(Bkmkr::Paths.submitted_images, "*")
-etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
-ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
-if etparr.any?
-  epubtitlepage = etparr.find { |e| /[\/|\\]epubtitlepage\./ =~ e }
-end
 
-if ptparr.any?
-  podtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
-end
-
-unless epubtitlepage.nil?
-	etpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
-	epubtitlepagearc = File.join(finalimagedir, etpfilename)
-	FileUtils.mv(epubtitlepage, epubtitlepagearc)
-end
-
-unless podtitlepage.nil?
-	ptpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+if File.file?(Metadata.podtitlepage)
+	ptpfilename = Metadata.podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
 	podtitlepagearc = File.join(finalimagedir, ptpfilename)
-	FileUtils.mv(podtitlepage, podtitlepagearc)
+	FileUtils.mv(Metadata.podtitlepage, podtitlepagearc)
+end
+
+if File.file?(Metadata.epubtitlepage)
+	etpfilename = Metadata.epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+	epubtitlepagearc = File.join(finalimagedir, etpfilename)
+	FileUtils.mv(Metadata.epubtitlepage, epubtitlepagearc)
 end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -53,7 +53,7 @@ end
 # find titlepage images
 
 images = File.join(Bkmkr::Paths.submitted_images, pisbn, "images")
-allimg = File.join(images, "*")
+allimg = File.join(Bkmkr::Paths.submitted_images, "*")
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
 

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -53,7 +53,7 @@ end
 # find titlepage images
 
 images = File.join(Bkmkr::Paths.submitted_images, pisbn, "images")
-allimg = File.join(finalimagedir, "*")
+allimg = File.join(images, "*")
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
 

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -52,7 +52,6 @@ end
 
 # find titlepage images
 
-images = File.join(Bkmkr::Paths.submitted_images, pisbn, "images")
 allimg = File.join(Bkmkr::Paths.submitted_images, "*")
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -52,7 +52,7 @@ end
 
 # find titlepage images
 
-images = File.join(Bkmkr::Paths.submitted_images, Metadata.pisbn, "images")
+images = File.join(Bkmkr::Paths.submitted_images, pisbn, "images")
 allimg = File.join(finalimagedir, "*")
 etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -40,12 +40,35 @@ if eisbn.length == 0
 	eisbn = Bkmkr::Project.filename
 end
 
+# find a front cover image
+
 fcfile = File.join(Bkmkr::Paths.submitted_images, "#{eisbn}_FC.jpg")
 
 if File.file?(fcfile)
 	frontcover = "#{eisbn}_FC.jpg"
 else
 	frontcover = "#{pisbn}_FC.jpg"
+end
+
+# find titlepage images
+
+images = File.join(Bkmkr::Paths.submitted_images, Metadata.pisbn, "images")
+allimg = File.join(finalimagedir, "*")
+etparr = Dir[allimg].select { |f| f.include?('epubtitlepage.')}
+ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
+
+if etparr.any?
+  epubtitlepage = etparr.find { |e| /[\/|\\]epubtitlepage\./ =~ e }
+elsif ptparr.any?
+  epubtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
+else
+  epubtitlepage = ""
+end
+
+if ptparr.any?
+  podtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
+else
+  podtitlepage = ""
 end
 
 # Finding author name(s)
@@ -117,6 +140,8 @@ File.open(configfile, 'w+') do |f|
 	f.puts '"printjs":"' + pdf_js_file + '",'
 	f.puts '"ebookcss":"' + epub_css_file + '",'
 	f.puts '"pod_toc":"' + toc_value + '",'
-	f.puts '"frontcover":"' + frontcover + '"'
+	f.puts '"frontcover":"' + frontcover + '",'
+	f.puts '"epubtitlepage":"' + epubtitlepage + '",'
+	f.puts '"podtitlepage":"' + podtitlepage + '"'
 	f.puts '}'
 end

--- a/pdfmaker_preprocessing.js
+++ b/pdfmaker_preprocessing.js
@@ -1,0 +1,27 @@
+var fs = require('fs');
+var cheerio = require('cheerio');
+var file = process.argv[2];
+
+fs.readFile(file, function editContent (err, contents) {
+  $ = cheerio.load(contents, {
+          xmlMode: true
+        });
+
+// add titlepage image if applicable
+  if ($('section[data-titlepage="yes"]').length) {
+  	//remove content
+  	$('section[data-type="titlepage"]').empty();
+  	//add image holder
+  	image = '<img src="titlepage_fullpage.jpg"/>';
+  	$('section[data-type="titlepage"]').append(image);
+  }
+
+  var output = $.html();
+	  fs.writeFile(file, output, function(err) {
+	    if(err) {
+	        return console.log(err);
+	    }
+
+	    console.log("Content has been updated!");
+	});
+});

--- a/pdfmaker_preprocessing.js
+++ b/pdfmaker_preprocessing.js
@@ -12,7 +12,7 @@ fs.readFile(file, function editContent (err, contents) {
   	//remove content
   	$('section[data-type="titlepage"]').empty();
   	//add image holder
-  	image = '<img src="titlepage_fullpage.jpg"/>';
+  	image = '<img src="images/titlepage_fullpage.jpg"/>';
   	$('section[data-type="titlepage"]').append(image);
   }
 

--- a/pdfmaker_preprocessing.js
+++ b/pdfmaker_preprocessing.js
@@ -12,7 +12,7 @@ fs.readFile(file, function editContent (err, contents) {
   	//remove content
   	$('section[data-type="titlepage"]').empty();
   	//add image holder
-  	image = '<img src="images/titlepage_fullpage.jpg"/>';
+  	image = '<figure class="fullpage"><img src="images/titlepage_fullpage.jpg"/></figure>';
   	$('section[data-type="titlepage"]').append(image);
   }
 

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -51,9 +51,10 @@ unless podtitlepage.nil?
   unless podfiletype == "jpg"
     `convert "#{podtitlepage}" "#{podtitlepagejpg}"`
     FileUtils.mv(podtitlepage, podtitlepagearc)
+    FileUtils.mv(podtitlepagejpg, podtitlepagetmp)
   end
-  FileUtils.cp(podtitlepagejpg, podtitlepagetmp)
   if File.file?(podtitlepage)
+  	FileUtils.cp(podtitlepage, podtitlepagetmp)
   	FileUtils.mv(podtitlepage, podtitlepagearc)
   end
   # insert titlepage image

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -110,7 +110,9 @@ if Bkmkr::Tools.os == "mac" or Bkmkr::Tools.os == "unix"
 	ftpfile = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_ftpupload", "imageupload.sh")
 	pdfimages = Dir.entries(pdftmp_dir).select { |f| !File.directory? f }
 	pdfimages.each do |i|
-		`#{ftpfile} #{i} #{pdftmp_dir}`
+		myfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+		puts myfile
+		`#{ftpfile} #{myfile} #{pdftmp_dir}`
 	end
 elsif Bkmkr::Tools.os == "windows"
 	ftpfile = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_ftpupload", "imageupload.bat")

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -47,7 +47,7 @@ unless podtitlepage.nil?
   File.open(pdf_tmp_html, 'w') do |output| 
     output.write filecontents
   end
-  unless tpfiletype == "jpg"
+  unless podfiletype == "jpg"
     `convert "#{podtitlepage}" "#{podtitlepagejpg}"`
     FileUtils.mv(podtitlepage, podtitlepagearc)
   end

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -41,7 +41,8 @@ unless podtitlepage.nil?
   puts "found a titlepage image"
   tpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   podtitlepagearc = File.join(finalimagedir, tpfilename)
-  podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage_fullpage.jpg")
+  podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage.jpg")
+  podtitlepagetmp = File.join(Bkmkr::Paths.project_tmp_dir_img, "titlepage_fullpage.jpg")
   podfiletype = tpfilename.split(".").pop
   filecontents = File.read(pdf_tmp_html).gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   File.open(pdf_tmp_html, 'w') do |output| 
@@ -51,8 +52,10 @@ unless podtitlepage.nil?
     `convert "#{podtitlepage}" "#{podtitlepagejpg}"`
     FileUtils.mv(podtitlepage, podtitlepagearc)
   end
-  FileUtils.cp(podtitlepagejpg, Bkmkr::Paths.project_tmp_dir_img)
-  FileUtils.mv(podtitlepagejpg, finalimagedir)
+  FileUtils.cp(podtitlepagejpg, podtitlepagetmp)
+  if File.file?(podtitlepage)
+  	FileUtils.mv(podtitlepage, podtitlepagearc)
+  end
   # insert titlepage image
   pdfmakerpreprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "pdfmaker_preprocessing.js")
   Bkmkr::Tools.runnode(pdfmakerpreprocessingjs, pdf_tmp_html)

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -133,33 +133,7 @@ end
 
 # TESTING
 
-# count, report images in file
-if image_count > 0
-
-	# test if sites are up/logins work?
-
-	# verify files were uploaded, and match image array
-    upload_report = []
-    File.read("#{Bkmkr::Paths.project_tmp_dir_img}/uploaded_image_log.txt").each_line {|line|
-          line_b = line.gsub(/\n$/, "")
-          upload_report.push line_b}
- 	upload_count = upload_report.count
-	
-	if upload_report.sort == images.sort
-		test_image_array_compare = "pass: Images in Done dir match images uploaded to ftp"
-	else
-		test_image_array_compare = "FAIL: Images in Done dir match images uploaded to ftp"
-	end
-	
-else
-	upload_count = 0
-	test_image_array_compare = "pass: There are no missing image files"
-end
-
 # Printing the test results to the log file
 File.open(Bkmkr::Paths.log_file, 'a+') do |f|
-	f.puts "----- PDFMAKER-PREPROCESSOR PROCESSES"
-	f.puts "----- I found #{image_count} images to be uploaded"
-	f.puts "----- I found #{upload_count} files uploaded"
-	f.puts "#{test_image_array_compare}"
+	f.puts "----- PDFMAKER-PREPROCESSING PROCESSES"
 end

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -36,8 +36,8 @@ end
 puts podtitlepage
 
 unless podtitlepage.nil?
-  puts "found a titlepage"
-  tpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
+  puts "found a titlepage image"
+  tpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   podtitlepagearc = File.join(finalimagedir, tpfilename)
   podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage_fullpage.jpg")
   podfiletype = etpfilename.split(".").pop

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -26,7 +26,7 @@ end
 
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
-allimg = File.join(images, "*")
+allimg = File.join(Bkmkr::Paths.submitted_images, "*")
 puts allimg
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
 puts ptparr

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -31,7 +31,7 @@ puts allimg
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
 puts ptparr
 if ptparr.any?
-  podtitlepage = ptparr.find { |e| /(\/?\\?)+titlepage\./ =~ e }
+  podtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
 end
 puts podtitlepage
 
@@ -41,11 +41,11 @@ unless podtitlepage.nil?
   podtitlepagearc = File.join(finalimagedir, tpfilename)
   podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage_fullpage.jpg")
   podfiletype = tpfilename.split(".").pop
-  filecontents = File.read(epub_tmp_html).gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
+  filecontents = File.read(pdf_tmp_html).gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   File.open(pdf_tmp_html, 'w') do |output| 
     output.write filecontents
   end
-  unless etpfiletype == "jpg"
+  unless tpfiletype == "jpg"
     `convert "#{podtitlepage}" "#{podtitlepagejpg}"`
     FileUtils.mv(podtitlepage, podtitlepagearc)
   end

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -24,6 +24,8 @@ unless File.exist?(pdftmp_dir)
 	Dir.mkdir(pdftmp_dir)
 end
 
+FileUtils.cp(Bkmkr::Paths.outputtmp_html, pdf_tmp_html)
+
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 allimg = File.join(Bkmkr::Paths.submitted_images, "*")
@@ -113,7 +115,7 @@ end
 
 # fixes images in html, keep final words and ellipses from breaking
 # .gsub(/([a-zA-Z0-9][a-zA-Z0-9][a-zA-Z0-9]\s\. \. \.)/,"<span class=\"bookmakerkeeptogetherkt\">\\0</span>")
-filecontents = File.read(Bkmkr::Paths.outputtmp_html).gsub(/src="images\//,"src=\"#{ftp_dir}/").gsub(/([a-zA-Z0-9]?[a-zA-Z0-9]?[a-zA-Z0-9]?\s\. \. \.)/,"<span class=\"bookmakerkeeptogetherkt\">\\0</span>").gsub(/(\s)(\w\w\w*?\.)(<\/p>)/,"\\1<span class=\"bookmakerkeeptogetherkt\">\\2</span>\\3")
+filecontents = File.read(pdf_tmp_html).gsub(/src="images\//,"src=\"#{ftp_dir}/").gsub(/([a-zA-Z0-9]?[a-zA-Z0-9]?[a-zA-Z0-9]?\s\. \. \.)/,"<span class=\"bookmakerkeeptogetherkt\">\\0</span>").gsub(/(\s)(\w\w\w*?\.)(<\/p>)/,"\\1<span class=\"bookmakerkeeptogetherkt\">\\2</span>\\3")
 
 File.open(pdf_tmp_html, 'w') do |output| 
   output.write filecontents

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -26,22 +26,18 @@ end
 
 FileUtils.cp(Bkmkr::Paths.outputtmp_html, pdf_tmp_html)
 
-images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
-allimg = File.join(Bkmkr::Paths.submitted_images, "*")
-puts allimg
+allimg = File.join(finalimagedir, "*")
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
-puts ptparr
 if ptparr.any?
   podtitlepage = ptparr.find { |e| /[\/|\\]titlepage\./ =~ e }
 end
-puts podtitlepage
 
 unless podtitlepage.nil?
-  puts "found a titlepage image"
+  puts "found a pod titlepage image"
   tpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   podtitlepagearc = File.join(finalimagedir, tpfilename)
-  podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage.jpg")
+  podtitlepagejpg = File.join(finalimagedir, "titlepage.jpg")
   podtitlepagetmp = File.join(Bkmkr::Paths.project_tmp_dir_img, "titlepage_fullpage.jpg")
   podfiletype = tpfilename.split(".").pop
   filecontents = File.read(pdf_tmp_html).gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
@@ -50,13 +46,9 @@ unless podtitlepage.nil?
   end
   unless podfiletype == "jpg"
     `convert "#{podtitlepage}" "#{podtitlepagejpg}"`
-    FileUtils.mv(podtitlepage, podtitlepagearc)
     FileUtils.mv(podtitlepagejpg, podtitlepagetmp)
   end
-  if File.file?(podtitlepage)
-  	FileUtils.cp(podtitlepage, podtitlepagetmp)
-  	FileUtils.mv(podtitlepage, podtitlepagearc)
-  end
+  FileUtils.cp(podtitlepage, podtitlepagetmp)
   # insert titlepage image
   pdfmakerpreprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "pdfmaker_preprocessing.js")
   Bkmkr::Tools.runnode(pdfmakerpreprocessingjs, pdf_tmp_html)

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -27,7 +27,9 @@ end
 images = Dir.entries(Bkmkr::Paths.submitted_images)
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 allimg = File.join(images, "*")
+puts allimg
 ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
+puts ptparr
 if ptparr.any?
   podtitlepage = ptparr.find { |e| /(\/?\\?)+titlepage\./ =~ e }
 end

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -18,6 +18,7 @@ pdftmp_dir = File.join(Bkmkr::Paths.project_tmp_dir_img, "pdftmp")
 pdfmaker_dir = File.join(Bkmkr::Paths.core_dir, "pdfmaker")
 pdf_tmp_html = File.join(Bkmkr::Paths.project_tmp_dir, "pdf_tmp.html")
 assets_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker")
+finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 
 # create pdf tmp directory
 unless File.exist?(pdftmp_dir)

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -40,7 +40,7 @@ unless podtitlepage.nil?
   tpfilename = podtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   podtitlepagearc = File.join(finalimagedir, tpfilename)
   podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage_fullpage.jpg")
-  podfiletype = etpfilename.split(".").pop
+  podfiletype = tpfilename.split(".").pop
   filecontents = File.read(epub_tmp_html).gsub(/(<section data-type="titlepage")/,"\\1 data-titlepage=\"yes\"")
   File.open(pdf_tmp_html, 'w') do |output| 
     output.write filecontents

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -31,8 +31,10 @@ ptparr = Dir[allimg].select { |f| f.include?('titlepage.')}
 if ptparr.any?
   podtitlepage = ptparr.find { |e| /(\/?\\?)+titlepage\./ =~ e }
 end
+puts podtitlepage
 
 unless podtitlepage.nil?
+  puts "found a titlepage"
   tpfilename = epubtitlepage.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   podtitlepagearc = File.join(finalimagedir, tpfilename)
   podtitlepagejpg = File.join(Bkmkr::Paths.submitted_images, "titlepage_fullpage.jpg")

--- a/pdfmaker_preprocessing.rb
+++ b/pdfmaker_preprocessing.rb
@@ -103,7 +103,6 @@ if Bkmkr::Tools.os == "mac" or Bkmkr::Tools.os == "unix"
 	pdfimages = Dir.entries(pdftmp_dir).select { |f| !File.directory? f }
 	pdfimages.each do |i|
 		myfile = i.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
-		puts myfile
 		`#{ftpfile} #{myfile} #{pdftmp_dir}`
 	end
 elsif Bkmkr::Tools.os == "windows"


### PR DESCRIPTION
Users can include separate title page images for POD and EPUB, specifying filenames in the project JSON.