### PR TITLE
Adding powershell script to convert .doc to .docx

### DIFF
--- a/htmlmaker_preprocessing.ps1
+++ b/htmlmaker_preprocessing.ps1
@@ -1,0 +1,72 @@
+﻿# Converts a .doc file in bookmaker_tmp to .docx
+# you can pass the original file location in convert, but then you have to run tmparchive.rb first
+# and of course set the correct location of bookmaker_tmp below
+param([string]$inputFile)
+
+# don't forget to set these for your Bookmaker environment!
+$logDir="C:\Users\erica.warren\bookmaker\log\"
+# the bookmaker_tmp dir, that is, without the root
+$tmpDir="\Users\erica.warren\bookmaker\bookmaker_tmp\" 	
+
+# getting the path inputs
+$currVolPath=Get-Location
+$currVol=split-path $currVolPath -Qualifier			#C: or S:	
+$filenameSplit=split-path $inputFile -Leaf			#file name without path
+write-host "Original file is " $filenameSplit
+$filename=$filenameSplit.SubString(0, $filenameSplit.LastIndexOf('.')).replace(' ','')	#filename w/out extension or spaces
+
+# define log file
+$Logfile =echo $($logDir + $filename + ".txt")
+
+Function LogWrite
+{
+   Param ([string]$logstring)
+   Add-content $Logfile -value "$logstring"
+}
+
+# if original file name is a .doc file
+$fileType = ".doc"
+If ($filenameSplit -eq $filename + $fileType)
+{
+	# Converts a word .doc in bookmaker_tmp to a .docx
+	# so you have to have already run tmparchive.rb
+	$folderpath=echo $($currVol + $tmpDir + $filename + "\" + $filename)
+	write-host "Converting $filenameSplit to .docx from $fileType..."
+
+	$SaveFormat = "microsoft.office.interop.word.WdSaveFormat" -as [type]
+	$word = New-Object -ComObject word.application
+	$word.visible = $false
+
+	$doc = $word.documents.open($folderpath + $fileType)
+	$wdFormatDocx = 16  # wdFormatDocumentDefault is docx, reference number is 16
+	#originally next line read:  $doc.saveas($path, $wdFormatDocx)
+	#Had to add [ref]s for certain versions of powershell (2.0), we'll see which way works on server
+	#https://richardspowershellblog.wordpress.com/2012/10/15/powershell-3-and-word/
+	#$doc.saveas($folderpath, $wdFormatDocx)
+	$doc.saveas([ref]$folderpath, [ref]$wdFormatDocx)
+	$doc.close()
+
+	$word.Quit()
+	$word = $null
+
+	# Next line if you want to remove the original .doc file
+	# Remove-Item ($folderpath + $fileType)
+}
+
+# TESTING
+
+LogWrite "----- DOC-TO-DOCX PROCESSES"
+
+#verify filename is not null
+if ($filenameSplit) {LogWrite "pass: original filename is not null"}
+Else {LogWrite "FAIL: original filename is not null"}
+
+#filename.docx should exist in tmp conversion dir
+$ChkFile = $($currVol + $tmpDir + $filename + "\" + $filename + ".docx")
+$FileExists = Test-Path $ChkFile 
+If ($FileExists -eq $True) {LogWrite "pass: inputFile.docx exists in $currVol$tmpDir."}
+Else {LogWrite "FAIL: inputFile.docx exists in $currVol$tmpDir."}
+
+
+[gc]::collect()
+[gc]::WaitForPendingFinalizers()

--- a/htmlmaker_preprocessing.ps1
+++ b/htmlmaker_preprocessing.ps1
@@ -39,13 +39,14 @@ If ($filenameSplit -eq $filename + $fileType)
 
 	$doc = $word.documents.open($folderpath + $fileType)
 	$wdFormatDocx = 16  # wdFormatDocumentDefault is docx, reference number is 16
-	#originally next line read:  $doc.saveas($path, $wdFormatDocx)
-	#Had to add [ref]s for certain versions of powershell (2.0), we'll see which way works on server
-	#https://richardspowershellblog.wordpress.com/2012/10/15/powershell-3-and-word/
-	#$doc.saveas($folderpath, $wdFormatDocx)
-	$doc.saveas([ref]$folderpath, [ref]$wdFormatDocx)
+	
+	# Have to add [ref]s for certain versions of powershell (2.0), we'll see which way works on server
+	# https://richardspowershellblog.wordpress.com/2012/10/15/powershell-3-and-word/
+	# so only use one or the other of these next two lines
+	$doc.saveas($folderpath, $wdFormatDocx)
+	#$doc.saveas([ref]$folderpath, [ref]$wdFormatDocx)
+	
 	$doc.close()
-
 	$word.Quit()
 	$word = $null
 

--- a/htmlmaker_preprocessing.ps1
+++ b/htmlmaker_preprocessing.ps1
@@ -4,9 +4,9 @@
 param([string]$inputFile)
 
 # don't forget to set these for your Bookmaker environment!
-$logDir="C:\Users\erica.warren\bookmaker\log\"
+$logDir="S:\resources\logs\"
 # the bookmaker_tmp dir, that is, without the root
-$tmpDir="\Users\erica.warren\bookmaker\bookmaker_tmp\" 	
+$tmpDir="\bookmaker_tmp\" 	
 
 # getting the path inputs
 $currVolPath=Get-Location


### PR DESCRIPTION
Fixes #27 

htmlmaker_preprocessing.ps1 checks if the input file in bookmaker_tmp is a .doc and if so, saves it as a .docx (also in bookmaker_tmp). It would be easy enough to do this in convert if necessary.

The original .doc file is retained in bookmaker_tmp as well (but if you want to delete it, just uncomment line 54).

doctoxml.py will still fail if a .doc is submitted.