### PR TITLE
Titlepage logo sources based on DW

### DIFF
--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -10,6 +10,7 @@ require_relative '../utilities/oraclequery.rb'
 data_hash = Mcmlln::Tools.readjson(Metadata.configfile)
 
 project_dir = data_hash['project']
+resource_dir = data_hash['resourcedir']
 
 epub_tmp_html = File.join(Bkmkr::Paths.project_tmp_dir, "epub_tmp.html")
 saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{Bkmkr::Tools.xslprocessor}.jar")
@@ -84,7 +85,7 @@ unless Metadata.epubtitlepage == "Unknown"
 end
 
 #set logo image based on project directory
-logo_img = File.join(assets_dir, "images", project_dir, "logo.jpg")
+logo_img = File.join(assets_dir, "images", resource_dir, "logo.jpg")
 
 #copy logo image file to epub folder if no epubtitlepage found
 if Metadata.epubtitlepage == "Unknown" and File.file?(logo_img)

--- a/imprints.json
+++ b/imprints.json
@@ -1,0 +1,69 @@
+{
+  "imprints": [
+  {
+  "formalname": "Tor.com",
+  "shortname": "torDOTcom",
+  "searchkey": "Tor.com"
+  },
+  {
+  "formalname": "Feiwel & Friends",
+  "shortname": "feiwel",
+  "searchkey": "Feiwel Friends"
+  },
+  {
+  "formalname": "Flatiron Books",
+  "shortname": "flatiron",
+  "searchkey": "Flatiron Books"
+  },
+  {
+  "formalname": "St. Martin's Griffin",
+  "shortname": "griffin",
+  "searchkey": "St Martin Griffin"
+  },
+  {
+  "formalname": "Henry Holt and Co. (BYR)",
+  "shortname": "holtbyr",
+  "searchkey": "Henry Holt BYR"
+  },
+  {
+  "formalname": "Henry Holt and Co. BYR Paperbacks",
+  "shortname": "holtbyr",
+  "searchkey": "Henry Holt BYR Paperbacks"
+  },
+  {
+  "formalname": "Imprint",
+  "shortname": "imprint",
+  "searchkey": "Imprint"
+  },
+  {
+  "formalname": "St. Martin's Press",
+  "shortname": "SMP",
+  "searchkey": "St Martin Press"
+  },
+  {
+  "formalname": "Square Fish",
+  "shortname": "squarefish",
+  "searchkey": "Square Fish"
+  },
+  {
+  "formalname": "Swerve",
+  "shortname": "swerve",
+  "searchkey": "Swerve"
+  },
+  {
+  "formalname": "Swoon Reads",
+  "shortname": "swoon",
+  "searchkey": "Swoon Reads"
+  },
+  {
+  "formalname": "Picador",
+  "shortname": "picador",
+  "searchkey": "Picador"
+  },
+  {
+  "formalname": "Picador Macmillan Trade",
+  "shortname": "picador",
+  "searchkey": "Picador Macmillan Trade"
+  }
+  ]
+}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -5,6 +5,23 @@ require 'json'
 require_relative '../bookmaker/core/header.rb'
 require_relative '../utilities/oraclequery.rb'
 
+# ---------------------- METHODS
+
+def getResourceDir(imprint, json)
+  data_hash = Mcmlln::Tools.readjson(json)
+  arr = []
+  # loop through each json record to see if imprint name matches formalname
+  data_hash['imprints'].each do |p|
+    if p['formalname'] == imprint
+      arr << p['shortname']
+    end
+  end
+  # in case of multiples, grab just the last entry and return it
+  path = arr.pop
+  return path
+end
+
+# ---------------------- PROCESSES
 # for logging purposes
 puts "RUNNING METADATA_PREPROCESSING"
 
@@ -189,6 +206,10 @@ else
 	imprint = imprint.encode('utf-8')
 end
 
+imprint_json = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "imprints.json")
+resource_dir = getResourceDir(imprint, imprint_json)
+puts resource_dir
+
 if !metapublisher.nil?
 	publisher = HTMLEntities.new.decode(metapublisher[2])
 else 
@@ -279,6 +300,7 @@ datahash.merge!(imprint: imprint)
 datahash.merge!(publisher: publisher)
 datahash.merge!(project: project_dir)
 datahash.merge!(stage: stage_dir)
+datahash.merge!(resourcedir: resource_dir)
 datahash.merge!(printcss: pdf_css_file)
 datahash.merge!(printjs: pdf_js_file)
 datahash.merge!(ebookcss: epub_css_file)

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -17,7 +17,11 @@ def getResourceDir(imprint, json)
     end
   end
   # in case of multiples, grab just the last entry and return it
-  path = arr.pop
+  if arr.nil? or arr.empty?
+    path = "generic"
+  else
+    path = arr.pop
+  end
   return path
 end
 
@@ -208,7 +212,6 @@ end
 
 imprint_json = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "imprints.json")
 resource_dir = getResourceDir(imprint, imprint_json)
-puts resource_dir
 
 if !metapublisher.nil?
 	publisher = HTMLEntities.new.decode(metapublisher[2])


### PR DESCRIPTION
The logo on epub titlepages will now be sourced based on the Imprint value fed by the Data Warehouse. If there is no corresponding logo, then the logo will be sourced by path, and then by generic macmillan.