### PR TITLE
Adjusting css path to pull based on imprint

### DIFF
--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -211,7 +211,6 @@ end
 project_dir = Bkmkr::Project.input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].pop.to_s.split("_").shift
 stage_dir = Bkmkr::Project.input_file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact))[0...-2].pop.to_s.split("_").pop
 imprint_json = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "imprints.json")
-resource_dir = getResourceDir(imprint, imprint_json)
 
 # Finding imprint name
 # imprint = File.read(Bkmkr::Paths.outputtmp_html).scan(/<p class="TitlepageImprintLineimp">.*?</).to_s.gsub(/\["<p class=\\"TitlepageImprintLineimp\\">/,"").gsub(/"\]/,"").gsub(/</,"")
@@ -234,6 +233,7 @@ end
 # print and epub css files
 epub_css_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "epubmaker", "css")
 pdf_css_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker", "css")
+resource_dir = getResourceDir(imprint, imprint_json)
 
 if !metatemplate.nil?
   template = HTMLEntities.new.decode(metatemplate[2])

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -234,29 +234,29 @@ end
 
 puts "Template: #{template}"
 
-if !metatemplate.nil? and File.file?("#{pdf_css_dir}/#{project_dir}/#{template}.css")
-  pdf_css_file = "#{pdf_css_dir}/#{project_dir}/#{template}.css"
-elsif File.file?("#{pdf_css_dir}/#{project_dir}/#{stage_dir}.css")
-  pdf_css_file = "#{pdf_css_dir}/#{project_dir}/#{stage_dir}.css"
-elsif File.file?("#{pdf_css_dir}/#{project_dir}/pdf.css")
-  pdf_css_file = "#{pdf_css_dir}/#{project_dir}/pdf.css"
+if !metatemplate.nil? and File.file?("#{pdf_css_dir}/#{resource_dir}/#{template}.css")
+  pdf_css_file = "#{pdf_css_dir}/#{resource_dir}/#{template}.css"
+elsif File.file?("#{pdf_css_dir}/#{resource_dir}/#{stage_dir}.css")
+  pdf_css_file = "#{pdf_css_dir}/#{resource_dir}/#{stage_dir}.css"
+elsif File.file?("#{pdf_css_dir}/#{resource_dir}/pdf.css")
+  pdf_css_file = "#{pdf_css_dir}/#{resource_dir}/pdf.css"
 else
   pdf_css_file = "#{pdf_css_dir}/torDOTcom/pdf.css"
 end
 
 puts "PDF CSS file: #{pdf_css_file}"
 
-if !metatemplate.nil? and File.file?("#{epub_css_dir}/#{project_dir}/#{template}.css")
-  epub_css_file = "#{epub_css_dir}/#{project_dir}/#{template}.css"
-elsif File.file?("#{epub_css_dir}/#{project_dir}/#{stage_dir}.css")
-  epub_css_file = "#{epub_css_dir}/#{project_dir}/#{stage_dir}.css"
-elsif File.file?("#{epub_css_dir}/#{project_dir}/epub.css")
-  epub_css_file = "#{epub_css_dir}/#{project_dir}/epub.css"
+if !metatemplate.nil? and File.file?("#{epub_css_dir}/#{resource_dir}/#{template}.css")
+  epub_css_file = "#{epub_css_dir}/#{resource_dir}/#{template}.css"
+elsif File.file?("#{epub_css_dir}/#{resource_dir}/#{stage_dir}.css")
+  epub_css_file = "#{epub_css_dir}/#{resource_dir}/#{stage_dir}.css"
+elsif File.file?("#{epub_css_dir}/#{resource_dir}/epub.css")
+  epub_css_file = "#{epub_css_dir}/#{resource_dir}/epub.css"
 else
   epub_css_file = "#{epub_css_dir}/generic/epub.css"
 end
 
-proj_js_file = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker", "scripts", project_dir, "pdf.js")
+proj_js_file = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker", "scripts", resource_dir, "pdf.js")
 fallback_js_file = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker", "scripts", "torDOTcom", "pdf.js")
 pdf_js_file = File.join(Bkmkr::Paths.project_tmp_dir, "pdf.js")
 

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -234,6 +234,7 @@ end
 epub_css_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "epubmaker", "css")
 pdf_css_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "pdfmaker", "css")
 resource_dir = getResourceDir(imprint, imprint_json)
+puts "Resource dir: #{resource_dir}"
 
 if !metatemplate.nil?
   template = HTMLEntities.new.decode(metatemplate[2])


### PR DESCRIPTION
CSS and JS will pull based on the imprint listed in Biblio. If no imprint is found, they will fall back to the conversion path, and then to generic path.