### PR TITLE
Getting product type isbns from data warehouse

### DIFF
--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -45,6 +45,18 @@ fs.readFile(file, function editContent (err, contents) {
     $(".temp").addClass(thisclass).removeClass("temp");
   });
 
+  //tag isbns if not tagged already
+  $("p[class^='CopyrightText']:not(:has(a.spanISBNisbn))").each(function () {
+      var mypattern1 = new RegExp( "978(\\D?\\d?){10}", "g");
+      var result1 = mypattern1.test($( this ).text());
+  console.log(result1);
+      if ( result1 === true ) {
+        var newtext = $( this ).text().replace(/(978(\D?\d?){10})/g, '<span class="spanISBNisbn">$1</span>');
+        $(this).empty();
+        $(this).prepend(newtext);
+      }
+    });
+
 
   var output = $.html();
     fs.writeFile(file, output, function(err) {

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -8,7 +8,9 @@ require_relative '../bookmaker/core/metadata.rb'
 # ---------------------- METHODS
 
 def fixISBNSpans(html)
+  # move any preceding non-digit content out of the isbn span tag
   filecontents = html.gsub(/(<span class="spanISBNisbn">)(\D+)(\d)/, "\\2\\1\\3")
+  # move any trailing non-digit content out of the isbn span tag
   filecontents = filecontents.gsub(/(<span class="spanISBNisbn">\s*978(\D?\d){10})((?!(<\/span>)).*?)(<\/span>)/, "\\1\\3\\2")
   return filecontents
 end

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -9,6 +9,7 @@ require_relative '../bookmaker/core/metadata.rb'
 
 def fixISBNSpans(html)
   filecontents = html.gsub(/(<span class="spanISBNisbn">)(\D+)(\d)/, "\\2\\1\\3")
+  filecontents = filecontents.gsub(/(<span class="spanISBNisbn">\s*978(\D?\d){10})((?!(<\/span>)).*?)(<\/span>)/, "\\1\\3\\2")
   return filecontents
 end
 

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -5,6 +5,15 @@ require_relative '../bookmaker/core/metadata.rb'
 
 # These commands should run immediately after htmlmaker
 
+# ---------------------- METHODS
+
+def fixISBNSpans(html)
+  filecontents = html.gsub(/(<span class="spanISBNisbn">)(\D+)(\d)/, "\\2\\1\\3")
+  return filecontents
+end
+
+# ---------------------- PROCESSES
+
 # run content conversions
 htmlmakerpostprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "htmlmaker_postprocessing.js")
 Bkmkr::Tools.runnode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html)
@@ -12,3 +21,8 @@ Bkmkr::Tools.runnode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html)
 # set html title to match JSON
 title_js = File.join(Bkmkr::Paths.core_dir, "htmlmaker", "title.js")
 Bkmkr::Tools.runnode(title_js, "#{Bkmkr::Paths.outputtmp_html} \"#{Metadata.booktitle}\"")
+
+filecontents = Mcmlln::Tools.readFile(Bkmkr::Paths.outputtmp_html)
+filecontents = fixISBNSpans(filecontents)
+
+Mcmlln::Tools.overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents)

--- a/imagechecker_postprocessing.rb
+++ b/imagechecker_postprocessing.rb
@@ -136,8 +136,12 @@ imgarr = listImages(filecontents)
 
 # run method: checkImages
 format, supported = checkImages(images, Bkmkr::Paths.project_tmp_dir_img)
-puts "UNSUPPORTED:"
-puts format
+
+# print a list of any unsupported image types
+unless format.nil? or format.empty? or !format
+  puts "UNSUPPORTED IMAGE TYPES:"
+  puts format
+end
 
 # run method: convertImages
 corrupt, converted = convertImages(supported, Bkmkr::Paths.project_tmp_dir_img)

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -71,7 +71,7 @@ puts "RUNNING METADATA_PREPROCESSING"
 
 # search for any isbn
 looseisbn = findAnyISBN(Bkmkr::Paths.outputtmp_html)
-puts looseisbn
+puts looseisbn.length
 pisbn = ""
 eisbn = ""
 isbnhash = {}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -288,11 +288,11 @@ puts "Resource dir: #{resource_dir}"
 
 if !metatemplate.nil?
   template = HTMLEntities.new.decode(metatemplate[2])
+  puts "Design template: #{template}"
 else
   template = ""
+  puts "Design template: default"
 end
-
-puts "Template: #{template}"
 
 if !metatemplate.nil? and File.file?("#{pdf_css_dir}/#{resource_dir}/#{template}.css")
   pdf_css_file = "#{pdf_css_dir}/#{resource_dir}/#{template}.css"

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -11,7 +11,7 @@ def findSpecificISBN(file, string)
   isbn_basestring = File.read(file).match(/<span class="spanISBNisbn">\s*978(\D?\d?){10}<\/span>\s*\(?#{string}\)?/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
-    isbn = isbn_basestring.match(/978\d{10}/).shift
+    isbn = isbn_basestring.match(/978\d{10}/)
   else
     isbn = ""
   end
@@ -22,7 +22,7 @@ def findAnyISBN(file)
   isbn_basestring = File.read(file).match(/spanISBNisbn">\s*978(\D?\d?){10}<\/span>/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
-    isbn = isbn_basestring.match(/978\d{10}/).shift
+    isbn = isbn_basestring.match(/978\d{10}/)
   else
     isbn = ""
   end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -10,8 +10,8 @@ require_relative '../utilities/oraclequery.rb'
 def findSpecificISBN(file, string)
   isbn_basestring = File.read(file).match(/<span class="spanISBNisbn">\s*978(\D?\d?){10}<\/span>\s*\(?#{string}\)?/)
   unless isbn_basestring.length == 0
-    isbn_basestring = isbn_basestring.shift.gsub(/-/,"").gsub(/\s+/,"")
-    isbn = isbn_basestring.match(/\d{13}/).shift
+    isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
+    isbn = isbn_basestring.match(/978\d{10}/).shift
   else
     isbn = ""
   end
@@ -21,8 +21,8 @@ end
 def findAnyISBN(file)
   isbn_basestring = File.read(file).match(/spanISBNisbn">\s*978(\D?\d?){10}<\/span>/)
   unless isbn_basestring.length == 0
-    isbn_basestring = isbn_basestring.shift.gsub(/-/,"").gsub(/\s+/,"")
-    isbn = isbn_basestring.match(/\d{13}/).shift
+    isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
+    isbn = isbn_basestring.match(/978\d{10}/).shift
   else
     isbn = ""
   end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -87,16 +87,15 @@ unless isbnhash.nil? or isbnhash.empty? or !isbnhash or isbnhash['book'].nil? or
   workid = isbnhash['book']['WORK_ID']
   thissql = exactSearchSingleKey(workid, "WORK_ID")
   editionshash = runQuery(thissql)
-  puts editionshash
+  hashfile = "/Users/nellie.mckesson/git/isbnhash.txt"
+  Mcmlln::Tools.overwriteFile(hashfile, editionshash)
   unless editionshash.nil? or editionshash.empty? or !editionshash
-    editionshash['book'].each do |b|
-      if b['PRODUCTTYPE_DESC'] and b['PRODUCTTYPE_DESC'] == "Book"
-        pisbn = b['EDITION_EAN']
-        puts b['EDITION_EAN']
+    editionshash.each do |k, v|
+      if v['PRODUCTTYPE_DESC'] and v['PRODUCTTYPE_DESC'] == "Book"
+        pisbn = v['EDITION_EAN']
         puts "Found a print product: #{pisbn}"
-      elsif b['PRODUCTTYPE_DESC'] and b['PRODUCTTYPE_DESC'] == "EBook"
-        eisbn = b['EDITION_EAN']
-        puts b['EDITION_EAN']
+      elsif v['PRODUCTTYPE_DESC'] and v['PRODUCTTYPE_DESC'] == "EBook"
+        eisbn = v['EDITION_EAN']
         puts "Found an ebook product: #{eisbn}"
       end
     end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -71,8 +71,6 @@ puts "RUNNING METADATA_PREPROCESSING"
 
 # search for any isbn
 looseisbn = findAnyISBN(Bkmkr::Paths.outputtmp_html)
-puts looseisbn.count('\\d')
-puts looseisbn.length
 pisbn = ""
 eisbn = ""
 isbnhash = {}
@@ -93,9 +91,11 @@ unless isbnhash.nil? or isbnhash.empty? or !isbnhash or isbnhash['book'].nil? or
     editionshash['book'].each do |b|
       if b['PRODUCTTYPE_DESC'] and b['PRODUCTTYPE_DESC'] == "Book"
         pisbn = b['EDITION_EAN']
+        puts b['EDITION_EAN']
         puts "Found a print product: #{pisbn}"
       elsif b['PRODUCTTYPE_DESC'] and b['PRODUCTTYPE_DESC'] == "EBook"
         eisbn = b['EDITION_EAN']
+        puts b['EDITION_EAN']
         puts "Found an ebook product: #{eisbn}"
       end
     end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -72,6 +72,7 @@ puts "RUNNING METADATA_PREPROCESSING"
 # search for any isbn
 looseisbn = findAnyISBN(Bkmkr::Paths.outputtmp_html)
 puts looseisbn.count('\\d')
+puts looseisbn.length
 pisbn = ""
 eisbn = ""
 isbnhash = {}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -11,7 +11,7 @@ def findSpecificISBN(file, string)
   isbn_basestring = File.read(file).match(/<span class="spanISBNisbn">\s*978(\D?\d?){10}<\/span>\s*\(?#{string}\)?/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
-    isbn = isbn_basestring.match(/978\d{10}/)
+    isbn = isbn_basestring.match(/978(\d{10})/)
   else
     isbn = ""
   end
@@ -22,7 +22,7 @@ def findAnyISBN(file)
   isbn_basestring = File.read(file).match(/spanISBNisbn">\s*978(\D?\d?){10}<\/span>/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
-    isbn = isbn_basestring.match(/978\d{10}/)
+    isbn = isbn_basestring.match(/978(\d{10})/)
   else
     isbn = ""
   end
@@ -71,6 +71,7 @@ puts "RUNNING METADATA_PREPROCESSING"
 
 # search for any isbn
 looseisbn = findAnyISBN(Bkmkr::Paths.outputtmp_html)
+puts looseisbn
 pisbn = ""
 eisbn = ""
 isbnhash = {}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -71,7 +71,7 @@ puts "RUNNING METADATA_PREPROCESSING"
 
 # search for any isbn
 looseisbn = findAnyISBN(Bkmkr::Paths.outputtmp_html)
-puts looseisbn.length
+puts looseisbn.count "\d"
 pisbn = ""
 eisbn = ""
 isbnhash = {}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -11,7 +11,7 @@ def findSpecificISBN(file, string)
   isbn_basestring = File.read(file).match(/<span class="spanISBNisbn">\s*978(\D?\d?){10}<\/span>\s*\(?#{string}\)?/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
-    isbn = isbn_basestring.match(/978(\d{10})/)
+    isbn = isbn_basestring.match(/978(\d{10})/).to_s
   else
     isbn = ""
   end
@@ -22,7 +22,7 @@ def findAnyISBN(file)
   isbn_basestring = File.read(file).match(/spanISBNisbn">\s*978(\D?\d?){10}<\/span>/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.to_s.gsub(/\D/,"")
-    isbn = isbn_basestring.match(/978(\d{10})/)
+    isbn = isbn_basestring.match(/978(\d{10})/).to_s
   else
     isbn = ""
   end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -19,7 +19,7 @@ def findSpecificISBN(file, string)
 end
 
 def findAnyISBN(file)
-  isbn_basestring = File.read(file).match(/spanISBNisbn">\s*978(\D?\d?){10}/)
+  isbn_basestring = File.read(file).match(/spanISBNisbn">\s*978(\D?\d?){10}<\/span>/)
   unless isbn_basestring.length == 0
     isbn_basestring = isbn_basestring.shift.gsub(/-/,"").gsub(/\s+/,"")
     isbn = isbn_basestring.match(/\d{13}/).shift

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -87,6 +87,7 @@ unless isbnhash.nil? or isbnhash.empty? or !isbnhash or isbnhash['book'].nil? or
   workid = isbnhash['book']['WORK_ID']
   thissql = exactSearchSingleKey(workid, "WORK_ID")
   editionshash = runQuery(thissql)
+  puts editionshash
   unless editionshash.nil? or editionshash.empty? or !editionshash
     editionshash['book'].each do |b|
       if b['PRODUCTTYPE_DESC'] and b['PRODUCTTYPE_DESC'] == "Book"

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -108,23 +108,17 @@ else
     if pisbn.length == 0
       pisbn = looseisbn
     end
+    unless pisbn.length == 0
+      puts "Found a print isbn: #{pisbn}"
+    end
     esearchstring = "(e|E)\s*-*\s*(b|B)ook"
     eisbn = findSpecificISBN(Bkmkr::Paths.outputtmp_html, esearchstring)
     if eisbn.length == 0
       eisbn = looseisbn
     end
-  end
-
-  # determining ebook isbn
-  if spanisbn.length != 0 && multiple_isbns.length != 0
-    eisbn_basestring = File.read(Bkmkr::Paths.outputtmp_html).match(/<span class="spanISBNisbn">\s*.+<\/span>\s*\((e|E)\s*-*\s*(b|B)ook\)/).to_s.gsub(/-/,"").gsub(/<span class="spanISBNisbn">/, "").gsub(/<\/span>/,"").gsub(/\s+/,"").gsub(/\["/,"").gsub(/"\]/,"")
-    eisbn = eisbn_basestring.match(/\d+\(ebook\)/).to_s.gsub(/\(ebook\)/,"").gsub(/\["/,"").gsub(/"\]/,"")
-  elsif spanisbn.length != 0 && multiple_isbns.length == 0
-    eisbn_basestring = File.read(Bkmkr::Paths.outputtmp_html).match(/spanISBNisbn">\s*.+<\/span>/).to_s.gsub(/-/,"").gsub(/<span class="spanISBNisbn">/, "").gsub(/<\/span>/,"").gsub(/\s+/,"").gsub(/\["/,"").gsub(/"\]/,"")
-    eisbn = pisbn_basestring.match(/\d+/).to_s.gsub(/\["/,"").gsub(/"\]/,"")
-  else
-    eisbn_basestring = File.read(Bkmkr::Paths.outputtmp_html).match(/ISBN\s*.+\s*\(e-*book\)/).to_s.gsub(/-/,"").gsub(/\s+/,"").gsub(/\["/,"").gsub(/"\]/,"")
-    eisbn = eisbn_basestring.match(/\d+\(ebook\)/).to_s.gsub(/\(.*\)/,"").gsub(/\["/,"").gsub(/"\]/,"")
+    unless eisbn.length == 0
+      puts "Found an ebook isbn: #{eisbn}"
+    end
   end
 end
 

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -71,7 +71,7 @@ puts "RUNNING METADATA_PREPROCESSING"
 
 # search for any isbn
 looseisbn = findAnyISBN(Bkmkr::Paths.outputtmp_html)
-puts looseisbn.count "\d"
+puts looseisbn.count('\\d')
 pisbn = ""
 eisbn = ""
 isbnhash = {}

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -94,6 +94,7 @@ unless isbnhash.nil? or isbnhash.empty? or !isbnhash or isbnhash['book'].nil? or
       elsif b['PRODUCTTYPE_DESC'] and b['PRODUCTTYPE_DESC'] == "EBook"
         eisbn = b['EDITION_EAN']
         puts "Found an ebook product: #{eisbn}"
+      end
     end
   end
 else

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -77,6 +77,7 @@ isbnhash = {}
 
 # query biblio, get WORK_ID
 if looseisbn.length == 13
+  puts "Searching data warehouse for ISBN: #{looseisbn}"
   thissql = exactSearchSingleKey(looseisbn, "EDITION_EAN")
   isbnhash = runQuery(thissql)
 end


### PR DESCRIPTION
Instead of determining product-specific isbns based on manuscript tagging, pull them from the data warehouse