### PR TITLE
Adjusting chap number insertion to screen for unnumbered chaps

### DIFF
--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -40,7 +40,9 @@ fs.readFile(file, function editContent (err, contents) {
   // add chap numbers to chap titles if specified
   $("h1[data-labeltext]").each(function () {
       var labeltext = $(this).attr('data-labeltext');
-      $(this).prepend(labeltext + ": ");    
+      if (labeltext.trim()) {
+        $(this).prepend(labeltext + ": "); 
+      };   
   });
 
 $("span.spanhyperlinkurl:not(:has(a))").each(function () {


### PR DESCRIPTION
This will fix that random extra ":" getting inserted before Epilogues, etc, in the EPUB file

@mattretzer can you review and merge?