### PR TITLE
adding validation for isbns from data warehouse

### DIFF
--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -116,12 +116,16 @@ unless isbnhash.nil? or isbnhash.empty? or !isbnhash or isbnhash['book'].nil? or
       allworks.push(v['EDITION_EAN'])
       # find a print product if it exists
       if v['PRODUCTTYPE_DESC'] and v['PRODUCTTYPE_DESC'] == "Book"
-        pisbn = v['EDITION_EAN']
-        puts "Found a print product: #{pisbn}"
+        if v['EDITION_EAN'].length == 13
+          pisbn = v['EDITION_EAN']
+          puts "Found a print product: #{pisbn}"
+        end
       # find an ebook product if it exists
       elsif v['PRODUCTTYPE_DESC'] and v['PRODUCTTYPE_DESC'] == "EBook"
-        eisbn = v['EDITION_EAN']
-        puts "Found an ebook product: #{eisbn}"
+        if v['EDITION_EAN'].length == 13
+          eisbn = v['EDITION_EAN']
+          puts "Found an ebook product: #{eisbn}"
+        end  
       end
     end
   end


### PR DESCRIPTION
This is a fix for addons issue 88, where a title in biblio with no isbn prevented metadata_preprocessing.rb from getting a true pisbn.

https://github.com/macmillanpublishers/bookmaker_addons/issues/88