### PR TITLE
Tag page placeholders as design notes

### DIFF
--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -26,7 +26,7 @@ fs.readFile(file, function editContent (err, contents) {
   // add extra paragraph to copyright page
   $('section[data-type="copyright-page"] p:last-child').removeClass( "CopyrightTextsinglespacecrtx" ).addClass( "CopyrightTextdoublespacecrtxd" );
 
-  var notice = '<p class="CopyrightTextdoublespacecrtx">Our eBooks may be purchased in bulk for promotional, educational, or business use. Please contact the Macmillan Corporate and Premium Sales Department at 1-800-221-7945, ext. 5442, or by e-mail at <a href="mailto:MacmillanSpecialMarkets@macmillan.com">MacmillanSpecialMarkets@macmillan.com</a>.</p>';
+  var notice = '<p class="CopyrightTextdoublespacecrtxd">Our eBooks may be purchased in bulk for promotional, educational, or business use. Please contact the Macmillan Corporate and Premium Sales Department at 1-800-221-7945, ext. 5442, or by e-mail at <a href="mailto:MacmillanSpecialMarkets@macmillan.com">MacmillanSpecialMarkets@macmillan.com</a>.</p>';
   
   var printnotice = $('section[data-type="copyright-page"] p:contains("Our books may be purchased in bulk")');
 

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -58,7 +58,7 @@ fs.readFile(file, function editContent (err, contents) {
     });
 
   // tag page placeholders as design notes
-  $('section h1 + p:last-child').each( function () {
+  $('section h1[class*="Nonprinting"] + p:last-child').each( function () {
     var mytext = $(this).text().trim();
     var mypattern = new RegExp( "^\[[i|I|v|V|x|X|0-9]+\]$", "g");
     var result = mypattern.test(mytext);

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -57,6 +57,16 @@ fs.readFile(file, function editContent (err, contents) {
       }
     });
 
+  // tag page placeholders as design notes
+  $('section h1 + p:last-child').each( function () {
+    var mytext = $(this).text().trim();
+    var mypattern = new RegExp( "^\[[i|I|v|V|x|X|0-9]+\]$", "g");
+    var result = mypattern.test(mytext);
+    if (result === true) {
+      $(this).removeClass().addClass("DesignNotedn");
+    }
+  });
+
   // remove design notes
   $('.DesignNotedn').remove();
 


### PR DESCRIPTION
Attempting to tag page placeholders as design notes. This only gets the ones that are on their own page. NB: This should ideally be solved by education.