### PR TITLE
Adding back the missing array to find the imprint

### DIFF
--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -50,7 +50,7 @@ end
 # for logging purposes
 puts "RUNNING METADATA_PREPROCESSING"
 
-pisbn, eisbn = findBookISBNs(Bkmkr::Paths.outputtmp_html, Bkmkr::Project.filename)
+pisbn, eisbn, allworks = findBookISBNs(Bkmkr::Paths.outputtmp_html, Bkmkr::Project.filename)
 
 # find titlepage images
 allimg = File.join(Bkmkr::Paths.submitted_images, "*")


### PR DESCRIPTION
Accidentally left it out when I moved isbn finder to it's own utility. Tested and working locally and on staging.

@ericawarren Erica can you review and approve?