### PR TITLE
Adding support for custom space break images

### DIFF
--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -33,6 +33,27 @@ def checkErrorFile(file)
   end
 end
 
+def listSpacebreakImages(file)
+  # An array of all the image files referenced in the source html file
+  imgarr = File.read(file).scan(/(figure class="Illustrationholderill customimage"><img src="images\/)(\S*)(")/)
+  imgarr.each do |o|
+    imgnames << o[1]
+  end
+  # remove duplicate image names from source array
+  imgnames = imgnames.uniq
+  imgnames
+end
+
+def convertSpacebreakImg(file, dir)
+  path_to_i = File.join(dir, file)
+  myres = `identify -format "%y" "#{path_to_i}"`
+  myres = myres.to_f
+  if File.file?(path_to_i)
+    puts "RESIZING #{path_to_i} for EPUB"
+    `convert "#{path_to_i}" -colorspace RGB -density #{myres} -resize "200x200>" -quality 100 "#{path_to_i}"`
+  end
+end
+
 # ---------------------- PROCESSES
 
 checkErrorFile(epubcheck_errfile)
@@ -94,6 +115,16 @@ File.open("#{OEBPS_dir}/content.opf", "w") {|file| file.puts replace}
 podtitlepagetmp = File.join(OEBPS_dir, "titlepage.jpg")
 if File.file?(podtitlepagetmp)
 	FileUtils.rm(podtitlepagetmp)
+end
+
+# adjust size of custom space break images
+# run method: listImages
+imgarr = listSpacebreakImages(Bkmkr::Paths.outputtmp_html)
+
+if imgarr.any?
+  imgarr.each do |i|
+    convertSpacebreakImg(i, OEBPS_dir)
+  end
 end
 
 csfilename = "#{Metadata.eisbn}_EPUB"

--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -36,6 +36,7 @@ end
 def listSpacebreakImages(file)
   # An array of all the image files referenced in the source html file
   imgarr = File.read(file).scan(/(figure class="Illustrationholderill customimage"><img src="images\/)(\S*)(")/)
+  imgnames = []
   imgarr.each do |o|
     imgnames << o[1]
   end

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -7,6 +7,8 @@ require_relative '../utilities/oraclequery.rb'
 
 # These commands should run immediately prior to epubmaker
 
+# ---------------------- VAIRABLES
+
 data_hash = Mcmlln::Tools.readjson(Metadata.configfile)
 
 project_dir = data_hash['project']
@@ -17,6 +19,10 @@ saxonpath = File.join(Bkmkr::Paths.resource_dir, "saxon", "#{Bkmkr::Tools.xslpro
 assets_dir = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_assets", "epubmaker")
 epub_img_dir = File.join(Bkmkr::Paths.project_tmp_dir, "epubimg")
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
+
+# ---------------------- METHODS
+
+# ---------------------- PROCESSES
 
 unless File.exist?(epub_img_dir)
     Dir.mkdir(epub_img_dir)
@@ -234,6 +240,7 @@ end
 # add some line breaks to make the html easier to deal with
 filecontents = filecontents.gsub(/(<p)/,"\n\\1")
 
+# write epub-ready html to file
 File.open(epub_tmp_html, 'w') do |output| 
   output.write filecontents
 end


### PR DESCRIPTION
Resizes custom space break images added by users via processing instruction, so that they appear nicely scaled in the epub.

@mattretzer Matt can you review and approve?