### PR TITLE
Fixing ATA author links

### DIFF
--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -186,7 +186,7 @@ if linkauthorarr.count > 1
   # insert new author links in newsletter
   # fix author links in ABA sections
   newslinkarr = []
-  linkauthorarr.each do |a|
+  linkauthorarr.each_with_index do |a, i|
     linkauthorname = a
     linkauthorfirst = a.split(" ").shift
     linkauthorlast = a.split(" ").pop

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -193,7 +193,7 @@ if linkauthorarr.count > 1
     linkauthornametxt = a.downcase.gsub(/\s/,"").gsub(/\W/,"").to_ascii
     linkauthornameall = a.downcase.gsub(/\s/,"").to_ascii
     thisauthorid - linkauthorid[i]
-    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}#{thisauthorid}#{linkauthornameall}\\3")
+    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}\\3#{thisauthorid}\\5#{linkauthornameall}\\7")
   end
   # another loop to fix the first ABA
   # and prepare the newsletter links
@@ -204,7 +204,7 @@ if linkauthorarr.count > 1
     linkauthornametxt = a.downcase.gsub(/\s/,"").gsub(/\W/,"").to_ascii
     linkauthornameall = a.downcase.gsub(/\s/,"").to_ascii
     thisauthorid - linkauthorid[i]
-    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}#{thisauthorid}#{linkauthornameall}\\3")
+    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}\\3#{thisauthorid}\\5#{linkauthornameall}\\7")
     thislink = "<p style=\"text-align: center; text-indent: 0;\">For email updates on #{a}, click <a href=\"http:\/\/us.macmillan.com\/authoralerts?authorName=#{linkauthornametxt}&amp;authorRefId=AUTHORID&amp;utm_source=ebook&amp;utm_medium=adcard&amp;utm_term=ebookreaders&amp;utm_content=#{linkauthornameall}_authoralertsignup_macdotcom&amp;utm_campaign=\{\{EISBN\}\}\">here.<\/a><\/p>"
     newslinkarr << thislink
   end

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -192,17 +192,19 @@ if linkauthorarr.count > 1
     linkauthorlast = a.split(" ").pop
     linkauthornametxt = a.downcase.gsub(/\s/,"").gsub(/\W/,"").to_ascii
     linkauthornameall = a.downcase.gsub(/\s/,"").to_ascii
-    filecontents = filecontents.gsub(/(--><\/p><\/section><section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornameall}\\3")
+    thisauthorid - linkauthorid[i]
+    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}#{thisauthorid}#{linkauthornameall}\\3")
   end
   # another loop to fix the first ABA
   # and prepare the newsletter links
-  linkauthorarr.each do |a|
+  linkauthorarr.each_with_index do |a, i|
     linkauthorname = a
     linkauthorfirst = a.split(" ").shift
     linkauthorlast = a.split(" ").pop
     linkauthornametxt = a.downcase.gsub(/\s/,"").gsub(/\W/,"").to_ascii
     linkauthornameall = a.downcase.gsub(/\s/,"").to_ascii
-    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornameall}\\3")
+    thisauthorid - linkauthorid[i]
+    filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}#{thisauthorid}#{linkauthornameall}\\3")
     thislink = "<p style=\"text-align: center; text-indent: 0;\">For email updates on #{a}, click <a href=\"http:\/\/us.macmillan.com\/authoralerts?authorName=#{linkauthornametxt}&amp;authorRefId=AUTHORID&amp;utm_source=ebook&amp;utm_medium=adcard&amp;utm_term=ebookreaders&amp;utm_content=#{linkauthornameall}_authoralertsignup_macdotcom&amp;utm_campaign=\{\{EISBN\}\}\">here.<\/a><\/p>"
     newslinkarr << thislink
   end

--- a/epubmaker_preprocessing.rb
+++ b/epubmaker_preprocessing.rb
@@ -192,7 +192,7 @@ if linkauthorarr.count > 1
     linkauthorlast = a.split(" ").pop
     linkauthornametxt = a.downcase.gsub(/\s/,"").gsub(/\W/,"").to_ascii
     linkauthornameall = a.downcase.gsub(/\s/,"").to_ascii
-    thisauthorid - linkauthorid[i]
+    thisauthorid = linkauthorid[i]
     filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}\\3#{thisauthorid}\\5#{linkauthornameall}\\7")
   end
   # another loop to fix the first ABA
@@ -203,7 +203,7 @@ if linkauthorarr.count > 1
     linkauthorlast = a.split(" ").pop
     linkauthornametxt = a.downcase.gsub(/\s/,"").gsub(/\W/,"").to_ascii
     linkauthornameall = a.downcase.gsub(/\s/,"").to_ascii
-    thisauthorid - linkauthorid[i]
+    thisauthorid = linkauthorid[i]
     filecontents = filecontents.gsub(/(<section data-type="appendix" class="abouttheauthor".*?#{linkauthorfirst}.*?#{linkauthorlast}.*?)(\{\{AUTHORNAMETXT\}\})(.*?)(\{\{AUTHORID\}\})(.*?)(\{\{AUTHORNAME\}\})(.*?>here<\/a>)/,"\\1#{linkauthornametxt}\\3#{thisauthorid}\\5#{linkauthornameall}\\7")
     thislink = "<p style=\"text-align: center; text-indent: 0;\">For email updates on #{a}, click <a href=\"http:\/\/us.macmillan.com\/authoralerts?authorName=#{linkauthornametxt}&amp;authorRefId=AUTHORID&amp;utm_source=ebook&amp;utm_medium=adcard&amp;utm_term=ebookreaders&amp;utm_content=#{linkauthornameall}_authoralertsignup_macdotcom&amp;utm_campaign=\{\{EISBN\}\}\">here.<\/a><\/p>"
     newslinkarr << thislink


### PR DESCRIPTION
Fixing the gsubs to make author links in About the Author sections work for multi-author books.

*This is fairly urgent.*

@mattretzer Matt can you review and approve?