### PR TITLE
Add http to links if missing

### DIFF
--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -92,13 +92,13 @@ fs.readFile(file, function editContent (err, contents) {
 
   // turn links into real hyperlinks
   $("span.spanhyperlinkurl:not(:has(a))").each(function () {
-    var newlink = "<a href='" + $( this ).text() + "'>" + $( this ).text() + "</a>";
+    var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
     var mypattern1 = new RegExp( "https?://", "g");
-    var result1 = mypattern1.test($( this ).text());
+    var result1 = mypattern1.test($(this).text());
     var mypattern2 = new RegExp( "^@", "g");
-    var result2 = mypattern2.test($( this ).text());
+    var result2 = mypattern2.test($(this).text());
     var mypattern3 = new RegExp( ".@.", "g");
-    var result3 = mypattern3.test($( this ).text());
+    var result3 = mypattern3.test($(this).text());
     if (result1 === false && result2 === false && result3 === false) {
       newlink = newlink.replace("href='", "href='http://");
     }
@@ -114,10 +114,12 @@ fs.readFile(file, function editContent (err, contents) {
 
   // fix link destinations
   $("a").each(function () {
-    var linkdest = $( this ).attr("href");
+    var linkdest = $(this).attr("href");
     var mypattern1 = new RegExp( "https?://", "g");
     var result1 = mypattern1.test(linkdest);
-    if (result1 === false) {
+    var mypattern2 = new RegExp( "^mailto:", "g");
+    var result2 = mypattern2.test(linkdest);
+    if (result1 === false && result2 == false) {
       linkdest = "http://" + linkdest;
     }
     $(this).attr("href", linkdest);

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -80,6 +80,16 @@ fs.readFile(file, function editContent (err, contents) {
   // removing this for now, leaving it to users to add this heading text for single-chapter books
   //$("section[data-type='chapter']:only-of-type > h1.ChapTitleNonprintingctnp").contents().replaceWith("Begin Reading");
 
+  // create hyperlinks from EBKLink paragraphs;
+  // keep this before the real-hyperlinks function
+  $(".EBKLinkSourceLa").each(function () {
+    var mySibling = $(this).next(".EBKLinkDestinationLb");
+    var myHref = mySibling.text();
+    var newLink = $("<a></a>").attr("href", myHref);
+    $(this).contents().wrap(newLink);
+    mySibling.remove();
+  });
+
   // turn links into real hyperlinks
   $("span.spanhyperlinkurl:not(:has(a))").each(function () {
     var newlink = "<a href='" + $( this ).text() + "'>" + $( this ).text() + "</a>";
@@ -100,15 +110,6 @@ fs.readFile(file, function editContent (err, contents) {
     }
     $(this).empty();
     $(this).prepend(newlink); 
-  });
-
-  // create hyperlinks from EBKLink paragraphs
-  $(".EBKLinkSourceLa").each(function () {
-    var mySibling = $(this).next(".EBKLinkDestinationLb");
-    var myHref = mySibling.text();
-    var newLink = $("<a></a>").attr("href", myHref);
-    $(this).contents().wrap(newLink);
-    mySibling.remove();
   });
 
   // convert small caps text to uppercase

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -81,7 +81,7 @@ fs.readFile(file, function editContent (err, contents) {
   //$("section[data-type='chapter']:only-of-type > h1.ChapTitleNonprintingctnp").contents().replaceWith("Begin Reading");
 
   // create hyperlinks from EBKLink paragraphs;
-  // keep this before the real-hyperlinks function
+  // keep this before the link destinations function
   $(".EBKLinkSourceLa").each(function () {
     var mySibling = $(this).next(".EBKLinkDestinationLb");
     var myHref = mySibling.text();
@@ -110,6 +110,17 @@ fs.readFile(file, function editContent (err, contents) {
     }
     $(this).empty();
     $(this).prepend(newlink); 
+  });
+
+  // fix link destinations
+  $("a").each(function () {
+    var linkdest = $( this ).attr("href");
+    var mypattern1 = new RegExp( "https?://", "g");
+    var result1 = mypattern1.test(linkdest);
+    if (result1 === false) {
+      linkdest = "http://" + linkdest;
+    }
+    $(this).attr("href", linkdest);
   });
 
   // convert small caps text to uppercase


### PR DESCRIPTION
Adds an "http" prefix to any links that are missing it. Will skip anything that already starts with http(s) or mailto. Fixes the epubcheck error we were getting in the testing dirs.

@mattretzer can you review and approve?