### PR TITLE
fixed second instance of travis test env var

### DIFF
--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -36,7 +36,7 @@ testing_value_file = File.join(Bkmkr::Paths.resource_dir, "staging.txt")
 # full path of epubcheck error file
 epubcheck_errfile = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "EPUBCHECK_ERROR.txt")
 
-unless defined?(ENV['TRAVIS_TEST'])
+unless (ENV['TRAVIS_TEST']) == 'true'
   @smtp_address = Mcmlln::Tools.readFile("#{$scripts_dir}/bookmaker_authkeys/smtp.txt")
 end
 


### PR DESCRIPTION
Hi @nelliemckesson please review! 
This also needs to be corrected as per [issue 137](https://github.com/macmillanpublishers/bookmaker_addons/issues/137), I missed this one on the last edit.

I tested this on stg to verify that this ( + [removing the newline on smtp.txt](https://github.com/macmillanpublishers/bookmaker_authkeys/pull/5) ) resolves issue 137.