### PR TITLE
Jsonlog diff for bookmaker_tests.rb

### DIFF
--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -105,7 +105,7 @@ jsonlog_hash.delete('cleanup.rb')
 Mcmlln::Tools.write_json(jsonlog_hash, vjsonlog_tmp)
 
 # check json log for differences - excluding timestamp lines (with "begun" or "completed" strings as specified)
-diff_jsonlog = `diff --ignore-matching-lines='"begun": "2' --ignore-matching-lines='"completed": "2' '#{vjsonlog_tmp}' '#{njsonlog}'`  #| sed -e '/'^#{stop_diff_line}',.*'#{stop_diff_line}'/,$d`
+diff_jsonlog = `diff -I '"begun": "2' -I '"completed": "2' '#{vjsonlog_tmp}' '#{njsonlog}'`
 
 File.open(testoutput, 'w') do |output|
   output.puts "----------CHECKING XML-----------"

--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -97,8 +97,8 @@ diff_ecss = `diff '#{vecss}' '#{necss}'`
 # check pdf css for differences
 diff_pcss = `diff '#{vpcss}' '#{npcss}'`
 
-# check json log for differences
-diff_jsonlog = `diff '#{vjsonlog}' '#{njsonlog}'`
+# check json log for differences - excluding timestamp lines (with "begun" or "completed" strings as specified)
+diff_jsonlog = `diff --ignore-matching-lines='"begun": "2' --ignore-matching-lines='"completed": "2' '#{vjsonlog}' '#{njsonlog}'`
 
 File.open(testoutput, 'w') do |output|
   output.puts "----------CHECKING XML-----------"

--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -38,6 +38,9 @@ final_epubfile = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.ei
 holding_epubfile = File.join(holding_path, "#{Metadata.eisbn}_EPUB.epub")
 final_pdffile = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "#{Metadata.pisbn}_POD.pdf")
 holding_pdffile = File.join(holding_path, "#{Metadata.pisbn}_POD.pdf")
+vjsonlog = File.join(verified_path, "#{Bkmkr::Project.filename}.json")
+njsonlog = Bkmkr::Paths.json_log
+holding_jsonlog = File.join(holding_path, "#{Bkmkr::Project.filename}.json")
 
 def prettyprintHTML(file, dir, prefix)
   contents = File.read(file)
@@ -94,7 +97,10 @@ diff_ecss = `diff '#{vecss}' '#{necss}'`
 # check pdf css for differences
 diff_pcss = `diff '#{vpcss}' '#{npcss}'`
 
-File.open(testoutput, 'w') do |output| 
+# check json log for differences
+diff_jsonlog = `diff '#{vjsonlog}' '#{njsonlog}'`
+
+File.open(testoutput, 'w') do |output|
   output.puts "----------CHECKING XML-----------"
   output.puts diff_xml
   output.puts "----------CHECKING PDF HTML-----------"
@@ -109,6 +115,8 @@ File.open(testoutput, 'w') do |output|
   output.puts diff_ecss
   output.puts "----------CHECKING PDF CSS-----------"
   output.puts diff_pcss
+  output.puts "----------CHECKING JSON_LOGFILE-----------"
+  output.puts diff_jsonlog
 end
 
 # Copy all new verified files to holding folder
@@ -121,6 +129,7 @@ Mcmlln::Tools.copyFile(final_epubfile, holding_epubfile)
 Mcmlln::Tools.copyFile(npcss, holding_pcss)
 Mcmlln::Tools.copyFile(necss, holding_ecss)
 Mcmlln::Tools.copyFile(nxml, holding_xml)
+Mcmlln::Tools.copyFile(njsonlog, holding_jsonlog)
 
 Mcmlln::Tools.deleteFile(nxml)
 Mcmlln::Tools.deleteFile(vhtml)

--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -107,10 +107,6 @@ jsonlog_hash.delete('cleanup_preprocessing.rb')
 jsonlog_hash.delete('cleanup.rb')
 Mcmlln::Tools.write_json(jsonlog_hash, vjsonlog_tmp)
 
-# # get the line index # at which we should begin ignoring the diff:
-# # (we need to exclude the cleanup scripts from diff)
-# stop_diff_line = `grep -n "cleanup_preprocessing.rb" '#{vjsonlog}'`.split[0].to_i - 2
-
 # check json log for differences - excluding timestamp lines (with "begun" or "completed" strings as specified)
 diff_jsonlog = `diff --ignore-matching-lines='"begun": "2' --ignore-matching-lines='"completed": "2' '#{vjsonlog_tmp}' '#{njsonlog}'`  #| sed -e '/'^#{stop_diff_line}',.*'#{stop_diff_line}'/,$d`
 

--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -42,9 +42,6 @@ vjsonlog = File.join(verified_path, "#{Bkmkr::Project.filename}.json")
 vjsonlog_tmp = File.join(testdir, "#{Bkmkr::Project.filename}_tmp.json")
 njsonlog = Bkmkr::Paths.json_log
 holding_jsonlog = File.join(holding_path, "#{Bkmkr::Project.filename}.json")
-vstdouterr_log = File.join(verified_path, "#{Bkmkr::Project.filename}-stdout-and-err.txt")
-nstdouterr_log = File.join(Bkmkr::Paths.log_dir, "#{Bkmkr::Project.filename}-stdout-and-err.txt")
-holding_stdouterr_log = File.join(holding_path, "#{Bkmkr::Project.filename}-stdout-and-err.txt")
 
 def prettyprintHTML(file, dir, prefix)
   contents = File.read(file)
@@ -110,9 +107,6 @@ Mcmlln::Tools.write_json(jsonlog_hash, vjsonlog_tmp)
 # check json log for differences - excluding timestamp lines (with "begun" or "completed" strings as specified)
 diff_jsonlog = `diff --ignore-matching-lines='"begun": "2' --ignore-matching-lines='"completed": "2' '#{vjsonlog_tmp}' '#{njsonlog}'`  #| sed -e '/'^#{stop_diff_line}',.*'#{stop_diff_line}'/,$d`
 
-# check stdout-and-err log for differences
-diff_stdouterr_log = `diff '#{vstdouterr_log}' '#{nstdouterr_log}'`
-
 File.open(testoutput, 'w') do |output|
   output.puts "----------CHECKING XML-----------"
   output.puts diff_xml
@@ -130,8 +124,6 @@ File.open(testoutput, 'w') do |output|
   output.puts diff_pcss
   output.puts "----------CHECKING JSON LOGFILE-----------"
   output.puts diff_jsonlog
-  output.puts "----------CHECKING STDOUTERR LOGFILE-----------"
-  output.puts diff_stdouterr_log
 end
 
 # Copy all new verified files to holding folder
@@ -145,7 +137,6 @@ Mcmlln::Tools.copyFile(npcss, holding_pcss)
 Mcmlln::Tools.copyFile(necss, holding_ecss)
 Mcmlln::Tools.copyFile(nxml, holding_xml)
 Mcmlln::Tools.copyFile(njsonlog, holding_jsonlog)
-Mcmlln::Tools.copyFile(nstdouterr_log, holding_stdouterr_log)
 
 Mcmlln::Tools.deleteFile(nxml)
 Mcmlln::Tools.deleteFile(vhtml)


### PR DESCRIPTION
@nelliemckesson , please review :)
Notable items:
- The diff command has a flag to ignore each script's begun/completed timestamp in the json log.
- Since at the time of the diff cmd, the jsonlog does not yet have contents for cleanup_preprocessing.rb or cleanup.rb (they haven't run yet), I am writing a 'temp jsonlog' file based on the verified jsonlog, with those entries removed.
- I tried to add the std-out-err_log in addition to the jsonlog..  but it doesn't have a normalized filename, since it's being written by the .bat, so any way that I would select it would have to be oddly specific and non-reusable.  Let me know if you want to rope that bit back in.

If/when this is approved & deployed I'll update the test files right away, o' course