### PR TITLE
Fixing fig id replacement in tests

### DIFF
--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -45,7 +45,7 @@ holding_jsonlog = File.join(holding_path, "#{Bkmkr::Project.filename}.json")
 
 def prettyprintHTML(file, dir, prefix)
   contents = File.read(file)
-  contents = contents.gsub(/(<[a-z])/, "\n\\0").gsub(/id="[\w-]*"/, "").gsub(/href="#[\w-]*"/, "")
+  contents = contents.gsub(/(<[a-z])/, "\n\\0").gsub(/ id="[\w-]*"/, " ").gsub(/href="#[\w-]*"/, "")
   filename = file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   newfile = File.join(dir, "#{prefix}_#{filename}")
   Mcmlln::Tools.overwriteFile(newfile, contents)

--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -45,7 +45,7 @@ holding_jsonlog = File.join(holding_path, "#{Bkmkr::Project.filename}.json")
 
 def prettyprintHTML(file, dir, prefix)
   contents = File.read(file)
-  contents = contents.gsub(/(<[a-z])/, "\n\\0").gsub(/ id="[\w-]*"/, " ").gsub(/href="#[\w-]*"/, "")
+  contents = contents.gsub(/(<[a-z])/, "\n\\0").gsub(/\sid="[\w-]*"/, "\s").gsub(/href="#[\w-]*"/, "")
   filename = file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   newfile = File.join(dir, "#{prefix}_#{filename}")
   Mcmlln::Tools.overwriteFile(newfile, contents)

--- a/bookmaker_tests.rb
+++ b/bookmaker_tests.rb
@@ -45,7 +45,7 @@ holding_jsonlog = File.join(holding_path, "#{Bkmkr::Project.filename}.json")
 
 def prettyprintHTML(file, dir, prefix)
   contents = File.read(file)
-  contents = contents.gsub(/(<[a-z])/, "\n\\0").gsub(/id="\w*"/, "").gsub(/href="#\w*"/, "")
+  contents = contents.gsub(/(<[a-z])/, "\n\\0").gsub(/id="[\w-]*"/, "").gsub(/href="#[\w-]*"/, "")
   filename = file.split(Regexp.union(*[File::SEPARATOR, File::ALT_SEPARATOR].compact)).pop
   newfile = File.join(dir, "#{prefix}_#{filename}")
   Mcmlln::Tools.overwriteFile(newfile, contents)


### PR DESCRIPTION
Fine-tuning the ID replacement to only apply to HTML ids and to catch hyphens in the id.