### PR TITLE
Adding class names to unstyled spans

### DIFF
--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -12,6 +12,10 @@ fs.readFile(file, function editContent (err, contents) {
           xmlMode: true
         });
 
+  // add missing class names to inline tags that were converted from direct formatting
+  $("strong:not(.spanboldfacecharactersbf)").addClass("spanboldfacecharactersbf");
+  $("em:not(.spanitaliccharactersital)").addClass("spanitaliccharactersital");
+
   // merge contiguous small caps char styles
   $("p[class^='ChapOpeningText']").each(function (i) {
    $(this).children("span.spansmallcapscharacterssc").each(function () {


### PR DESCRIPTION
The second piece of https://github.com/macmillanpublishers/htmlmaker_js/issues/40

This code adds in the required Macmillan styles to any inline tags that were created from direct formatting in Word.