### PR TITLE
Section head links to TOC

### DIFF
--- a/epubmaker_postprocessing.js
+++ b/epubmaker_postprocessing.js
@@ -8,7 +8,7 @@ fs.readFile(file, function editContent (err, contents) {
         });
 
 // Add links back to TOC to all section heads and part heads
-$("body>section h1, div[data-type='part']>section h1, div[data-type='part'] h1").each(function () {
+$("body>section>h1, div[data-type='part']>section>h1, div[data-type='part']>h1").each(function () {
   var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
   $(this).empty();
   $(this).prepend(newlink);

--- a/epubmaker_postprocessing.js
+++ b/epubmaker_postprocessing.js
@@ -7,33 +7,12 @@ fs.readFile(file, function editContent (err, contents) {
           xmlMode: true
         });
 
-// Add links back to TOC to chapter heads
-  $("section[data-type='chapter'] h1").each(function () {
-    var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
-    $(this).empty();
-    $(this).prepend(newlink); 
-  });
-
-// Add links back to TOC to appendix heads
-  $("section[data-type='appendix'] h1").each(function () {
-    var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
-    $(this).empty();
-    $(this).prepend(newlink); 
-  });
-
-// add link back to TOC to preface heads
-  $("section[data-type='preface'] h1").each(function () {
-    var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
-    $(this).empty();
-    $(this).prepend(newlink); 
-  });
-
-// Add links back to TOC to part heads
-  $("div[data-type='part'] h1").each(function () {
-    var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
-    $(this).empty();
-    $(this).prepend(newlink); 
-  });
+// Add links back to TOC to all section heads and part heads
+$("body>section h1, div[data-type='part']>section h1, div[data-type='part'] h1").each(function () {
+  var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
+  $(this).empty();
+  $(this).prepend(newlink);
+});
 
   var output = $.html();
 	  fs.writeFile(file, output, function(err) {

--- a/epubmaker_postprocessing.js
+++ b/epubmaker_postprocessing.js
@@ -8,7 +8,7 @@ fs.readFile(file, function editContent (err, contents) {
         });
 
 // Add links back to TOC to all section heads and part heads
-$("body>section>h1, div[data-type='part']>section>h1, div[data-type='part']>h1").each(function () {
+$("body>section>div>h1, div[data-type='part']>section>h1, div[data-type='part']>h1").each(function () {
   var newlink = "<a href='toc01.html'>" + $( this ).text() + "</a>";
   $(this).empty();
   $(this).prepend(newlink);

--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -59,8 +59,8 @@ end
 
 def getHTMLfilenameTypes(styleconfig_hash, logkey='')
   types = []
-  styleconfig_hash['toplevelheads'].each do |key, array|
-	   types << array[0]['type']
+  styleconfig_hash['toplevelheads'].each do |key, hash|
+	   types << hash['type']
   end
   return types
 rescue => logstring

--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -291,23 +291,10 @@ htmlfileshortnames = getHTMLfileShortNames(chunk_xsl, 'get_html_file_short_names
 # combine the 2 arrays of html filename prefix possiblities
 htmlfilenames.concat htmlfileshortnames
 
-puts htmlfilenames
-
+# for every html file in OEBPS with one of these filename prefixes, run create links to TOC for every heading.
 htmlfilenames.each { |prefix|
   addLinkstoTOC(oebps_dir, "#{prefix}[0-9][0-9]*.html", epubmakerpostprocessingjs, "add_TOC_links_to_heads_in_#{prefix}.html_files")
 }
-
-# # Add links back to TOC to chapter heads
-# addLinkstoTOC(oebps_dir, "ch[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_chap_heads')
-#
-# # Add links back to TOC to appendix heads
-# addLinkstoTOC(oebps_dir, "app[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_appendix_heads')
-#
-# # Add links back to TOC to preface heads
-# addLinkstoTOC(oebps_dir, "preface[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_preface_heads')
-#
-# # Add links back to TOC to part heads
-# addLinkstoTOC(oebps_dir, "part[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_part_heads')
 
 # fix toc entry in ncx
 # fix title page text in ncx

--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -62,7 +62,7 @@ def getHTMLfilenameTypes(styleconfig_hash, logkey='')
   styleconfig_hash['toplevelheads'].each do |key, array|
 	   types << array[0]['type']
   end
-  return types.uniq
+  return types
 rescue => logstring
   return []
 ensure
@@ -78,7 +78,7 @@ def getHTMLfileShortNames(chunk_xsl, logkey='')
   		shortnames << line.split(':')[1].strip()
   	end
   }
-  return shortnames.uniq
+  return shortnames
 rescue => logstring
   return []
 ensure
@@ -292,7 +292,7 @@ htmlfileshortnames = getHTMLfileShortNames(chunk_xsl, 'get_html_file_short_names
 htmlfilenames.concat htmlfileshortnames
 
 # for every html file in OEBPS with one of these filename prefixes, create links to TOC for every heading.
-htmlfilenames.each { |prefix|
+htmlfilenames.uniq.each { |prefix|
   addLinkstoTOC(oebps_dir, "#{prefix}[0-9][0-9]*.html", epubmakerpostprocessingjs, "add_TOC_links_to_heads_in_#{prefix}.html_files")
 }
 

--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'net/smtp'
+require 'nokogiri'
 
 unless (ENV['TRAVIS_TEST']) == 'true'
   require_relative '../bookmaker/core/header.rb'
@@ -14,6 +15,10 @@ end
 # ---------------------- VARIABLES
 
 local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
+
+styleconfig_json = File.join(Bkmkr::Paths.scripts_dir, "htmlmaker_js", "style_config.json")
+
+chunk_xsl = File.join(Bkmkr::Paths.scripts_dir, "HTMLBook", "htmlbook-xsl", "chunk.xsl")
 
 oebps_dir = File.join(Bkmkr::Paths.project_tmp_dir, "OEBPS")
 
@@ -42,11 +47,40 @@ end
 
 # ---------------------- METHODS
 
-def readConfigJson(logkey='')
-  data_hash = Mcmlln::Tools.readjson(Metadata.configfile)
+## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+def readJson(jsonfile, logkey='')
+  data_hash = Mcmlln::Tools.readjson(jsonfile)
   return data_hash
 rescue => logstring
   return {}
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def getHTMLfilenameTypes(styleconfig_hash, logkey='')
+  types = []
+  styleconfig_hash['toplevelheads'].each do |key, array|
+	   types << array[0]['type']
+  end
+  return types.uniq
+rescue => logstring
+  return []
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def getHTMLfileShortNames(chunk_xsl, logkey='')
+  shortnames = []
+  doc = File.open(chunk_xsl) { |f| Nokogiri::XML(f) }
+  node = doc.xpath('//xsl:param[@name="output.filename.prefix.by.data-type"]').first.content
+  node.each_line { |line|
+  	unless line.strip().empty?
+  		shortnames << line.split(':')[1].strip()
+  	end
+  }
+  return shortnames.uniq
+rescue => logstring
+  return []
 ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
@@ -241,24 +275,39 @@ end
 
 # ---------------------- PROCESSES
 
-data_hash = readConfigJson('read_config_json')
-#local definition(s) based on config.json
-stage_dir = data_hash['stage']
-
 # If an epubcheck_errfile exists, delete it
 deleteFileIfPresent(epubcheck_errfile, 'delete_epubcheck_errfile')
 
-# Add links back to TOC to chapter heads
-addLinkstoTOC(oebps_dir, "ch[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_chap_heads')
+data_hash = readJson(Metadata.configfile, 'read_config_json')
+#local definition(s) based on config.json
+stage_dir = data_hash['stage']
 
-# Add links back to TOC to appendix heads
-addLinkstoTOC(oebps_dir, "app[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_appendix_heads')
+styleconfig_hash = readJson(styleconfig_json, 'read_styleconfig_json')
 
-# Add links back to TOC to preface heads
-addLinkstoTOC(oebps_dir, "preface[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_preface_heads')
+htmlfilenames = getHTMLfilenameTypes(styleconfig_hash, 'get_html_filename-types')
 
-# Add links back to TOC to part heads
-addLinkstoTOC(oebps_dir, "part[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_part_heads')
+htmlfileshortnames = getHTMLfileShortNames(chunk_xsl, 'get_html_file_short_names')
+
+# combine the 2 arrays of html filename prefix possiblities
+htmlfilenames.concat htmlfileshortnames
+
+puts htmlfilenames
+
+htmlfilenames.each { |prefix|
+  addLinkstoTOC(oebps_dir, "#{prefix}[0-9][0-9]*.html", epubmakerpostprocessingjs, "add_TOC_links_to_heads_in_#{prefix}.html_files")
+}
+
+# # Add links back to TOC to chapter heads
+# addLinkstoTOC(oebps_dir, "ch[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_chap_heads')
+#
+# # Add links back to TOC to appendix heads
+# addLinkstoTOC(oebps_dir, "app[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_appendix_heads')
+#
+# # Add links back to TOC to preface heads
+# addLinkstoTOC(oebps_dir, "preface[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_preface_heads')
+#
+# # Add links back to TOC to part heads
+# addLinkstoTOC(oebps_dir, "part[0-9][0-9]*.html", epubmakerpostprocessingjs, 'add_links_to_TOC_to_part_heads')
 
 # fix toc entry in ncx
 # fix title page text in ncx

--- a/epubmaker_postprocessing.rb
+++ b/epubmaker_postprocessing.rb
@@ -288,10 +288,10 @@ htmlfilenames = getHTMLfilenameTypes(styleconfig_hash, 'get_html_filename-types'
 
 htmlfileshortnames = getHTMLfileShortNames(chunk_xsl, 'get_html_file_short_names')
 
-# combine the 2 arrays of html filename prefix possiblities
+# combine the 2 arrays of html filename prefix-possiblities
 htmlfilenames.concat htmlfileshortnames
 
-# for every html file in OEBPS with one of these filename prefixes, run create links to TOC for every heading.
+# for every html file in OEBPS with one of these filename prefixes, create links to TOC for every heading.
 htmlfilenames.each { |prefix|
   addLinkstoTOC(oebps_dir, "#{prefix}[0-9][0-9]*.html", epubmakerpostprocessingjs, "add_TOC_links_to_heads_in_#{prefix}.html_files")
 }


### PR DESCRIPTION
Hi @nelliemckesson , please review;
this is to fix https://github.com/macmillanpublishers/bookmaker_addons/issues/156

To get all the possible *.html name targets I grabbed the toplevelheads from the style_config.json, and the abbreviations listed in the chunk.xsl in HTMLBook (using nokogiri to parse the xml)

I tested all of the bad files listed in the linked issue, everything that should have links had links :)