### PR TITLE
URGENT: Fixing long hyphenated words and strings

### DIFF
--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -100,14 +100,14 @@ fs.readFile(file, function editContent (err, contents) {
   });
 
   // some special handling for paras with long hyphenated phrases
-  $('p:contains("-")').each(function ()){
+  $('p:contains("-")').each(function (){
     var para_txt = $(this).text();
     var myRegexp = /((\S+-){3,})/;
     var match = myRegexp.exec(para_txt);
     if (match === true) {
       $(this).attr('style', 'prince-hyphenate-after: 6; prince-hyphenate-before: 6; hyphenate-lines: 6;');
     }
-  }
+  });
 
   var output = $.html();
     fs.writeFile(file, output, function(err) {

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -99,6 +99,16 @@ fs.readFile(file, function editContent (err, contents) {
     $(this).after(match[4]);
   });
 
+  // some special handling for paras with long hyphenated phrases
+  $('p:contains("-")').each(function ()){
+    var para_txt = $(this).text();
+    var myRegexp = /((\S+-){3,})/;
+    var match = myRegexp.exec(para_txt);
+    if (match === true) {
+      $(this).attr('style', 'prince-hyphenate-after: 6; prince-hyphenate-before: 6; hyphenate-lines: 6;');
+    }
+  }
+
   var output = $.html();
     fs.writeFile(file, output, function(err) {
       if(err) {

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -102,7 +102,7 @@ fs.readFile(file, function editContent (err, contents) {
   // some special handling for paras with long hyphenated phrases
   $('p:contains("-")').each(function (){
     var para_txt = $(this).text();
-    var mypattern = /((\S+-){3,})/g;
+    var mypattern = /((\S+-){4,})/g;
     var result = mypattern.test(para_txt);
     if (result === true) {
       $(this).addClass('longstring');

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -102,10 +102,10 @@ fs.readFile(file, function editContent (err, contents) {
   // some special handling for paras with long hyphenated phrases
   $('p:contains("-")').each(function (){
     var para_txt = $(this).text();
-    var myRegexp = /((\S+-){3,})/;
-    var match = myRegexp.exec(para_txt);
-    if (match === true) {
-      $(this).attr('style', 'prince-hyphenate-after: 6; prince-hyphenate-before: 6; hyphenate-lines: 6;');
+    var mypattern = /\S-/g;
+    var result = mypattern.test(para_txt);
+    if (result === true) {
+      $(this).addClass('longstring');
     }
   });
 

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -102,7 +102,7 @@ fs.readFile(file, function editContent (err, contents) {
   // some special handling for paras with long hyphenated phrases
   $('p:contains("-")').each(function (){
     var para_txt = $(this).text();
-    var mypattern = /\S-/g;
+    var mypattern = /((\S+-){3,})/g;
     var result = mypattern.test(para_txt);
     if (result === true) {
       $(this).addClass('longstring');

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){3,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#x200B;-&#x200B;")
+    newstring = l[0].gsub(/-/, "&#x200B;&shy;&#x200B;")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -40,6 +40,21 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
+def fixLongHyphenatedWords(html, logkey='')
+  filecontents = html
+  longstrings = html.scan(/((\S+-){3,})/)
+  longstrings.each do |l|
+    source = l[0]
+    newstring = l[0].gsub(/-/, "&#8202;-&#8202;")
+    filecontents = filecontents.gsub(source, newstring)
+  end
+  return filecontents  
+rescue => logstring
+  return ''
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
 def overwriteFile(path,filecontents, logkey='')
 	Mcmlln::Tools.overwriteFile(path, filecontents)

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){3,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#x200B; &#173; &#x200B;")
+    newstring = l[0].gsub(/-/, "&#x200B;&#173;&#x200B;")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -42,7 +42,7 @@ end
 
 def fixLongHyphenatedWords(html, logkey='')
   filecontents = html
-  longstrings = html.scan(/((\S+-){3,})/)
+  longstrings = html.scan(/((\S+-){4,})/)
   longstrings.each do |l|
     source = l[0]
     newstring = l[0].gsub(/-/, "&#x200B;-&#173;&#x200B;")

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){3,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#x200B;&shy;&#x200B;")
+    newstring = l[0].gsub(/-/, "&#x200B; &shy; &#x200B;")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){3,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#x200B; &shy; &#x200B;")
+    newstring = l[0].gsub(/-/, "&#x200B; &#173; &#x200B;")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -71,6 +71,7 @@ localRunNode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html, 'post-proce
 
 filecontents = readOutputHtml('read_output_html')
 filecontents = fixNoteCallouts(filecontents, 'fix_note_callouts')
+filecontents = fixLongHyphenatedWords(filecontents, 'fix_long_hyphenated_phrases')
 
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_html')
 

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){3,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#8202;-&#8202;")
+    newstring = l[0].gsub(/-/, "&#x200B;-&#x200B;")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){3,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#x200B;&#173;&#x200B;")
+    newstring = l[0].gsub(/-/, "&#x200B;-&#173;&#x200B;")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -45,7 +45,7 @@ def fixLongHyphenatedWords(html, logkey='')
   longstrings = html.scan(/((\S+-){4,})/)
   longstrings.each do |l|
     source = l[0]
-    newstring = l[0].gsub(/-/, "&#x200B;-&#173;&#x200B;")
+    newstring = l[0].gsub(/-/, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>")
     filecontents = filecontents.gsub(source, newstring)
   end
   return filecontents  


### PR DESCRIPTION
Adds a tiny space around hyphens in long strings, to allow for better spacing and line breaking. This is a bug fix for a book currently in production.