### PR TITLE
Longhyphenurl

### DIFF
--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -42,13 +42,31 @@ end
 
 def fixLongHyphenatedWords(html, logkey='')
   filecontents = html
+  # tag & alter long-hyphen phrases that are parts or hyperlinks (so they are bypassed by the next block)
+  longhyphenhyperlinks = html.scan(/(<a href="(?:(?!<a href).)*?(([a-zA-Z]+-){4,}).*?<\/a>)/)
+  longhyphenhyperlinks.each do |lh|
+    source = lh[0]
+    newstring = lh[0].gsub(/(^.*$)/, 'LONGHYPHENHYPERLINK\1ENDLONGHYPHENHYPERLINK').gsub(/-/, "zzzzz") #(placeholders for easy cleanup gsubs)
+    filecontents = filecontents.gsub(source, newstring)
+  end
+
+  # capture and replace all other long-hyphen phrases
   longstrings = html.scan(/(([a-zA-Z]+-){4,})/)
   longstrings.each do |l|
     source = l[0]
     newstring = l[0].gsub(/-/, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>")
     filecontents = filecontents.gsub(source, newstring)
   end
-  return filecontents  
+
+  # return long-hyphen-hypen strings in hyperlinks to their previous state
+  taggedhyphenhyperlinks = filecontents.scan(/LONGHYPHENHYPERLINK.*?ENDLONGHYPHENHYPERLINK/)
+  taggedhyphenhyperlinks.each do |th|
+    source = th
+    newstring = th.gsub(/LONGHYPHENHYPERLINK(.*?)ENDLONGHYPHENHYPERLINK/, '\1').gsub(/zzzzz/, "-") #(placeholders for easy cleanup gsubs)
+    filecontents = filecontents.gsub(source, newstring)
+  end
+
+  return filecontents
 rescue => logstring
   return ''
 ensure

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -42,8 +42,8 @@ end
 
 def fixLongHyphenatedWords(html, logkey='')
   filecontents = html
-  # tag & alter long-hyphen phrases that are parts or hyperlinks (so they are bypassed by the next block)
-  longhyphenhyperlinks = html.scan(/(<a href="(?:(?!<a href).)*?(([a-zA-Z]+-){4,}).*?<\/a>)/)
+  # tag & alter long-hyphen phrases that are parts of hyperlinks (so they are bypassed by the next block's transformation)
+  longhyphenhyperlinks = html.scan(/(<span class="spanhyperlinkurl">(?:(?!<span).)*?(([a-zA-Z]+-){4,}).*?<\/span>)/)
   longhyphenhyperlinks.each do |lh|
     source = lh[0]
     newstring = lh[0].gsub(/(^.*$)/, 'LONGHYPHENHYPERLINK\1ENDLONGHYPHENHYPERLINK').gsub(/-/, "zzzzz") #(placeholders for easy cleanup gsubs)


### PR DESCRIPTION
@nelliemckesson please review..
This PR is to address https://github.com/macmillanpublishers/bookmaker_addons/issues/168, which resulted in two epubcheck errors last week for egalleymaker & one in bookmaker_galley.

It's a bit of an awkward fix; it would be cleaner to  check if a matched pattern was part of a hyperlink span in js; but then I'd need to move the whole pattern replacement into js so I figured for now I'd stick with what you'd done in ruby.  Let me know if you'd like me to revise and do this in js instead :)

PS tested this with the bad files and it works as desired; this also passes bookmaker_tests.