### PR TITLE
Longhyphenurl js

### DIFF
--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -101,17 +101,17 @@ fs.readFile(file, function editContent (err, contents) {
 
   // special handling for paras with long hyphenated phrases.
   $('p:contains("-"):not(:has(span.spanISBNisbn))').each(function (){
-  // verify we have a long-hyphen-phrase pattern match somewhere here before proceeding any further
   var para_html = $(this).html();
   // for the regexp, we could use greedier (/((\S+-){3,})/), but this could select hyphens inside of markup tags
   // we could also use (/((\S+(<span.*?>)*-(<span.*?>)*){3,})/) to get long-hyphenated phrases that cross span tags
   //  but this results in nested spans
   var mypattern = new RegExp(/((\w+-){3,})/);  // using the 'g' gives inconsistent results with 'regexp.test(pattern)'
-  var mypattern_g = new RegExp(/((\w+-){3,})/g);  // butwe need the 'g' when making replacements
+  var mypattern_g = new RegExp(/((\w+-){3,})/g);  // but we need the 'g' when making replacements
 
+  // verify we have a long-hyphen-phrase pattern match somewhere here before proceeding any further
   if (mypattern.test(para_html)) {
     var new_para_html = para_html
-    // change long-hyphen strings in this paragraph's hyperlink spans to preserve them during the next transformation
+    // change long-hyphen strings in hyperlink spans to preserve them during the next transformation
     var url_hyphen_placeholder = 'zzzzz - zzzzz'
     var hyperlink_span = $(this).find(".spanhyperlinkurl")
       hyperlink_span.each(function(){
@@ -136,13 +136,13 @@ fs.readFile(file, function editContent (err, contents) {
       });
     }
 
-    // remove all the temporary hyperlink long-hyphen placeholders
+    // remove all the temporary long-hyphen-hyperlink placeholders
     if (new_para_html.search(url_hyphen_placeholder)>0) {
       var urlplaceholderregex = new RegExp(url_hyphen_placeholder, "g")
       new_para_html = new_para_html.replace(urlplaceholderregex, "-")
     }
 
-    // apply the above transformations and add 'longstring' class
+    // apply the above transformations and add 'longstring' class to the para
     $(this).html(new_para_html)
     $(this).addClass('longstring');
   };

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -102,11 +102,11 @@ fs.readFile(file, function editContent (err, contents) {
   // special handling for paras with long hyphenated phrases.
   $('p:contains("-"):not(:has(span.spanISBNisbn))').each(function (){
   var para_html = $(this).html();
-  // for the regexp, we could use greedier (/((\S+-){3,})/), but this could select hyphens inside of markup tags
-  // we could also use (/((\S+(<span.*?>)*-(<span.*?>)*){3,})/) to get long-hyphenated phrases that cross span tags
+  // for the regexp, we could use greedier (/((\S+-){4,})/), but this could select hyphens inside of markup tags
+  // we could also use (/((\S+(<span.*?>)*-(<span.*?>)*){4,})/) to get long-hyphenated phrases that cross span tags
   //  but this results in nested spans
-  var mypattern = new RegExp(/((\w+-){3,})/);  // using the 'g' gives inconsistent results with 'regexp.test(pattern)'
-  var mypattern_g = new RegExp(/((\w+-){3,})/g);  // but we need the 'g' when making replacements
+  var mypattern = new RegExp(/((\w+-){4,})/);  // using the 'g' gives inconsistent results with 'regexp.test(pattern)'
+  var mypattern_g = new RegExp(/((\w+-){4,})/g);  // but we need the 'g' when making replacements
 
   // verify we have a long-hyphen-phrase pattern match in this paragraph
   if (mypattern.test(para_html)) {

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -99,15 +99,54 @@ fs.readFile(file, function editContent (err, contents) {
     $(this).after(match[4]);
   });
 
-  // some special handling for paras with long hyphenated phrases
+  // special handling for paras with long hyphenated phrases.
   $('p:contains("-"):not(:has(span.spanISBNisbn))').each(function (){
-    var para_txt = $(this).text();
-    var mypattern = /((\S+-){3,})/g;
-    var result = mypattern.test(para_txt);
-    if (result === true) {
-      $(this).addClass('longstring');
+  // verify we have a long-hyphen-phrase pattern match somewhere here before proceeding any further
+  var para_html = $(this).html();
+  // for the regexp, we could use greedier (/((\S+-){3,})/), but this could select hyphens inside of markup tags
+  // we could also use (/((\S+(<span.*?>)*-(<span.*?>)*){3,})/) to get long-hyphenated phrases that cross span tags
+  //  but this results in nested spans
+  var mypattern = new RegExp(/((\w+-){3,})/);  // using the 'g' gives inconsistent results with 'regexp.test(pattern)'
+  var mypattern_g = new RegExp(/((\w+-){3,})/g);  // butwe need the 'g' when making replacements
+
+  if (mypattern.test(para_html)) {
+    var new_para_html = para_html
+    // change long-hyphen strings in this paragraph's hyperlink spans to preserve them during the next transformation
+    var url_hyphen_placeholder = 'zzzzz - zzzzz'
+    var hyperlink_span = $(this).find(".spanhyperlinkurl")
+      hyperlink_span.each(function(){
+        var hyperlink_text = $(this).text()
+        var new_hyperlink_text = hyperlink_text
+        if (mypattern.test(hyperlink_text)) {
+          patternmatches = hyperlink_text.match(mypattern_g)
+          patternmatches.forEach(function(string){
+            newstring = string.replace(/-/g, url_hyphen_placeholder)
+            new_hyperlink_text = new_hyperlink_text.replace(string,newstring)
+            new_para_html = new_para_html.replace(hyperlink_text, new_hyperlink_text)
+          });
+        };
+      });
+
+    // transform all the other long-hyphenated strings
+    if (mypattern.test(new_para_html)) {
+      patternmatches = new_para_html.match(mypattern_g)
+      patternmatches.forEach(function(string){
+        newstring = string.replace(/-/g, "<span style='font-size: 2pt;'> </span>&&&<span style='font-size: 2pt;'> </span>")
+        new_para_html = new_para_html.replace(string, newstring)
+      });
     }
-  });
+
+    // remove all the temporary hyperlink long-hyphen placeholders
+    if (new_para_html.search(url_hyphen_placeholder)>0) {
+      var urlplaceholderregex = new RegExp(url_hyphen_placeholder, "g")
+      new_para_html = new_para_html.replace(urlplaceholderregex, "-")
+    }
+
+    // apply the above transformations and add 'longstring' class
+    $(this).html(new_para_html)
+    $(this).addClass('longstring');
+  };
+});
 
   var output = $.html();
     fs.writeFile(file, output, function(err) {

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -108,7 +108,7 @@ fs.readFile(file, function editContent (err, contents) {
   var mypattern = new RegExp(/((\w+-){3,})/);  // using the 'g' gives inconsistent results with 'regexp.test(pattern)'
   var mypattern_g = new RegExp(/((\w+-){3,})/g);  // but we need the 'g' when making replacements
 
-  // verify we have a long-hyphen-phrase pattern match somewhere here before proceeding any further
+  // verify we have a long-hyphen-phrase pattern match in this paragraph
   if (mypattern.test(para_html)) {
     var new_para_html = para_html
     // change long-hyphen strings in hyperlink spans to preserve them during the next transformation
@@ -131,7 +131,7 @@ fs.readFile(file, function editContent (err, contents) {
     if (mypattern.test(new_para_html)) {
       patternmatches = new_para_html.match(mypattern_g)
       patternmatches.forEach(function(string){
-        newstring = string.replace(/-/g, "<span style='font-size: 2pt;'> </span>&&&<span style='font-size: 2pt;'> </span>")
+        newstring = string.replace(/-/g, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>")
         new_para_html = new_para_html.replace(string, newstring)
       });
     }

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -40,21 +40,6 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def fixLongHyphenatedWords(html, logkey='')
-  filecontents = html
-  longstrings = html.scan(/(([a-zA-Z]+-){4,})/)
-  longstrings.each do |l|
-    source = l[0]
-    newstring = l[0].gsub(/-/, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>")
-    filecontents = filecontents.gsub(source, newstring)
-  end
-  return filecontents  
-rescue => logstring
-  return ''
-ensure
-  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
-
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
 def overwriteFile(path,filecontents, logkey='')
 	Mcmlln::Tools.overwriteFile(path, filecontents)
@@ -71,7 +56,6 @@ localRunNode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html, 'post-proce
 
 filecontents = readOutputHtml('read_output_html')
 filecontents = fixNoteCallouts(filecontents, 'fix_note_callouts')
-filecontents = fixLongHyphenatedWords(filecontents, 'fix_long_hyphenated_phrases')
 
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_html')
 


### PR DESCRIPTION
@nelliemckesson, please review.
This is an all javascript version of the previous patch for issue https://github.com/macmillanpublishers/bookmaker_addons/issues/168

After some consideration I ended up using the same basic method as I had in Ruby; temporarily modifying long-hyphen phrases in hyperlinks, doing the desired replacements on all other long-hyphen phrases, then reverting the hyperlinks to their initial state.  Tested, and it works, looks good via bookmaker_tests as well.

Two notes: 
1) I absorbed your javascript long-hyphen handling (adding longtext class) into my handling; that may have been incorrect, but it would be easy to re-instate your bit and remove the addClass from mine, just let me know!
2) The regexp you had in ruby for text replacements was different from the one you had in javascript for applying class 'longtext'. The ruby one required at least 4 consecutive hyphens interspersed with text; the latter 3. And the text selector was different ([a-zA-Z] versus \S).  I chose to look for 4 occurrences and picked a selector in between: "\w". 