### PR TITLE
Fixing hyphens, but leaving URLs alone

### DIFF
--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -86,7 +86,7 @@ fs.readFile(file, function editContent (err, contents) {
     mySibling.remove();
   });
 
-    // turn links into real hyperlinks
+  // turn links into real hyperlinks
   $("span.spanhyperlinkurl:not(:has(a))").each(function () {
     var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
     var mypattern1 = new RegExp( "https?://", "g");

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -86,28 +86,6 @@ fs.readFile(file, function editContent (err, contents) {
     mySibling.remove();
   });
 
-  // turn links into real hyperlinks
-  $("span.spanhyperlinkurl:not(:has(a))").each(function () {
-    var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
-    var mypattern1 = new RegExp( "https?://", "g");
-    var result1 = mypattern1.test($(this).text());
-    var mypattern2 = new RegExp( "^@", "g");
-    var result2 = mypattern2.test($(this).text());
-    var mypattern3 = new RegExp( ".@.", "g");
-    var result3 = mypattern3.test($(this).text());
-    if (result1 === false && result2 === false && result3 === false) {
-      newlink = newlink.replace("href='", "href='http://");
-    }
-    if (result1 === false && result2 === true) {
-      newlink = newlink.replace("href='@", "href='https://twitter.com/");
-    }
-    if (result2 === false && result3 === true) {
-      newlink = newlink.replace("href='", "href='mailto:");
-    }
-    $(this).empty();
-    $(this).prepend(newlink); 
-  });
-
   // fix link destinations
   $("a").each(function () {
     var linkdest = $(this).attr("href");

--- a/epubmaker_preprocessing.js
+++ b/epubmaker_preprocessing.js
@@ -86,6 +86,28 @@ fs.readFile(file, function editContent (err, contents) {
     mySibling.remove();
   });
 
+    // turn links into real hyperlinks
+  $("span.spanhyperlinkurl:not(:has(a))").each(function () {
+    var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
+    var mypattern1 = new RegExp( "https?://", "g");
+    var result1 = mypattern1.test($(this).text());
+    var mypattern2 = new RegExp( "^@", "g");
+    var result2 = mypattern2.test($(this).text());
+    var mypattern3 = new RegExp( ".@.", "g");
+    var result3 = mypattern3.test($(this).text());
+    if (result1 === false && result2 === false && result3 === false) {
+      newlink = newlink.replace("href='", "href='http://");
+    }
+    if (result1 === false && result2 === true) {
+      newlink = newlink.replace("href='@", "href='https://twitter.com/");
+    }
+    if (result2 === false && result3 === true) {
+      newlink = newlink.replace("href='", "href='mailto:");
+    }
+    $(this).empty();
+    $(this).prepend(newlink); 
+  });
+
   // fix link destinations
   $("a").each(function () {
     var linkdest = $(this).attr("href");

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -102,7 +102,7 @@ fs.readFile(file, function editContent (err, contents) {
   function replaceHyphenatedStrings() {
     // Next we'll add some special handling for 
     // long strings connected by hyphens.
-    // Note that is the link replacements from the function above
+    // Note that if the link replacements from the function above
     // do not occur before this function, then hyphens within link 
     // text WILL NOT be spaced. (However, link href attributes will
     // always be left alone.)
@@ -155,7 +155,7 @@ fs.readFile(file, function editContent (err, contents) {
                 // For each hyphenated text string we find,
                 // we'll add the parent para id, the source string text, and our new markup to a hash.
                 var oldString = patternMatches[i];
-                var newString = patternMatches[i].replace(/-/g, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>")
+                var newString = patternMatches[i].replace(/-/g, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>");
                 // Wrap the hyphanted strings in a span for future potential targetting
                 newString = "<span class='longstring'>" + newString + "</span>";
                 hashReplacements[counter] = [];
@@ -173,7 +173,7 @@ fs.readFile(file, function editContent (err, contents) {
     // Now we loop through that hash and do the text replacements
     // by targeting just the paragraph in which the strings occur
     Object.keys(hashReplacements).forEach(function (key) { 
-      var value = hashReplacements[key]
+      var value = hashReplacements[key];
       var selection = value[0];
       var searchString = value[1];
       var replacementString = value[2];

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -99,28 +99,6 @@ fs.readFile(file, function editContent (err, contents) {
     $(this).after(match[4]);
   });
 
-  // // turn links into real hyperlinks
-  // $("span.spanhyperlinkurl:not(:has(a))").each(function () {
-  //   var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
-  //   var mypattern1 = new RegExp( "https?://", "g");
-  //   var result1 = mypattern1.test($(this).text());
-  //   var mypattern2 = new RegExp( "^@", "g");
-  //   var result2 = mypattern2.test($(this).text());
-  //   var mypattern3 = new RegExp( ".@.", "g");
-  //   var result3 = mypattern3.test($(this).text());
-  //   if (result1 === false && result2 === false && result3 === false) {
-  //     newlink = newlink.replace("href='", "href='http://");
-  //   }
-  //   if (result1 === false && result2 === true) {
-  //     newlink = newlink.replace("href='@", "href='https://twitter.com/");
-  //   }
-  //   if (result2 === false && result3 === true) {
-  //     newlink = newlink.replace("href='", "href='mailto:");
-  //   }
-  //   $(this).empty();
-  //   $(this).prepend(newlink); 
-  // });
-
   function replaceHyphenatedStrings() {
     // Next we'll add some special handling for 
     // long strings connected by hyphens.

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -99,27 +99,27 @@ fs.readFile(file, function editContent (err, contents) {
     $(this).after(match[4]);
   });
 
-  // turn links into real hyperlinks
-  $("span.spanhyperlinkurl:not(:has(a))").each(function () {
-    var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
-    var mypattern1 = new RegExp( "https?://", "g");
-    var result1 = mypattern1.test($(this).text());
-    var mypattern2 = new RegExp( "^@", "g");
-    var result2 = mypattern2.test($(this).text());
-    var mypattern3 = new RegExp( ".@.", "g");
-    var result3 = mypattern3.test($(this).text());
-    if (result1 === false && result2 === false && result3 === false) {
-      newlink = newlink.replace("href='", "href='http://");
-    }
-    if (result1 === false && result2 === true) {
-      newlink = newlink.replace("href='@", "href='https://twitter.com/");
-    }
-    if (result2 === false && result3 === true) {
-      newlink = newlink.replace("href='", "href='mailto:");
-    }
-    $(this).empty();
-    $(this).prepend(newlink); 
-  });
+  // // turn links into real hyperlinks
+  // $("span.spanhyperlinkurl:not(:has(a))").each(function () {
+  //   var newlink = "<a href='" + $(this).text() + "'>" + $(this).text() + "</a>";
+  //   var mypattern1 = new RegExp( "https?://", "g");
+  //   var result1 = mypattern1.test($(this).text());
+  //   var mypattern2 = new RegExp( "^@", "g");
+  //   var result2 = mypattern2.test($(this).text());
+  //   var mypattern3 = new RegExp( ".@.", "g");
+  //   var result3 = mypattern3.test($(this).text());
+  //   if (result1 === false && result2 === false && result3 === false) {
+  //     newlink = newlink.replace("href='", "href='http://");
+  //   }
+  //   if (result1 === false && result2 === true) {
+  //     newlink = newlink.replace("href='@", "href='https://twitter.com/");
+  //   }
+  //   if (result2 === false && result3 === true) {
+  //     newlink = newlink.replace("href='", "href='mailto:");
+  //   }
+  //   $(this).empty();
+  //   $(this).prepend(newlink); 
+  // });
 
   function replaceHyphenatedStrings() {
     // Next we'll add some special handling for 

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -137,11 +137,22 @@ fs.readFile(file, function editContent (err, contents) {
     $('p:contains("-"):not(:has(span.spanISBNisbn))').each(function (){
       var para_txt = $(this).text();
       var myhtml = $(this).html();
+      var myID = $(this).attr("id");
       // Check to see if the paragraph contains any long strings
       var testLongString = /((\S+-){4,})/g;
       var result = testLongString.test(para_txt);
       if (result === true) {
-        // If yes, we'll start by replacing hyphens in any child elements within the para
+        // Make sure the paragraph has an ID
+        if (myID === undefined) {
+          var newID = function () {
+            // Math.random should be unique because of its seeding algorithm.
+            // Convert it to base 36 (numbers + letters), and grab the first 9 characters
+            // after the decimal.
+            return '_' + Math.random().toString(36).substr(2, 9);
+          };
+          $(this).attr("id", newID);
+        }
+        // Replace hyphens in any child elements within the para
         $(this).find("*:not(.spanhyperlinkurl)").each(function () {
           $(this).html( $(this).html().replace(/-/g,"<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>") );
         });

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -40,21 +40,6 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def fixLongHyphenatedWords(html, logkey='')
-  filecontents = html
-  longstrings = html.scan(/(([a-zA-Z]+-){4,})/)
-  longstrings.each do |l|
-    source = l[0]
-    newstring = l[0].gsub(/-/, "<span style='font-size: 2pt;'> </span>-<span style='font-size: 2pt;'> </span>")
-    filecontents = filecontents.gsub(source, newstring)
-  end
-  return filecontents  
-rescue => logstring
-  return ''
-ensure
-  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
-
 ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
 def overwriteFile(path,filecontents, logkey='')
 	Mcmlln::Tools.overwriteFile(path, filecontents)
@@ -71,7 +56,6 @@ localRunNode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html, 'post-proce
 
 filecontents = readOutputHtml('read_output_html')
 filecontents = fixNoteCallouts(filecontents, 'fix_note_callouts')
-filecontents = fixLongHyphenatedWords(filecontents, 'fix_long_hyphenated_phrases')
 
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_html')
 


### PR DESCRIPTION
A new fix for the hyphenated words problem. See comments inline. This will add spaces around hyphenated text strings, including strings that have nested inline formatting, but will not affect URLs (as long as they are tagged correctly).