### PR TITLE
Wsymfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
 - 2.0.0
+before_install:
+- nvm install node
 branches:
   only:
   - master

--- a/filearchive_postprocessing.rb
+++ b/filearchive_postprocessing.rb
@@ -97,7 +97,7 @@ def versionCompare(v1, v2, logkey='')
     logstring = "template_version is nil; htmlmaker_preprocessing.rb may have crashed?"
     return false
   elsif v1.empty?
-    logstring = "template_version is empty; input file is html or this is a non-Macmillan bookmaker instance"
+    logstring = "template_version is empty; .docx has no version, input file is html, or this is a non-Macmillan bookmaker instance"
     return false
   elsif v1.match(/[^\d.]/) || v2.match(/[^\d.]/)
     logstring = "template_version string includes nondigit chars: returning false."

--- a/filearchive_postprocessing.rb
+++ b/filearchive_postprocessing.rb
@@ -134,9 +134,10 @@ end
 def writeVersionErrfile(htmlmaker_js_version_test, errfile, helpurl, logkey='')
   if htmlmaker_js_version_test == false
   	File.open(errfile, 'w') do |output|
-  		output.puts "This document was styled using the old Macmillan style-template."
-  		output.puts "\nThe bookmaker toolchain has been updated: to generate valid PDF and ePub output you must attach the latest style-template, and add Section Start styles to your document as needed."
-  		output.puts "\nFor more information please go to this page: #{helpurl}"
+  		output.puts "This document was styled using the old Macmillan style template."
+  		output.puts "\nThe bookmaker toolchain has been updated: to generate valid PDFs and ePubs you must attach the latest style template, and add Section Start styles to your document as needed."
+      output.puts "\nYou can also use the Stylecheck-converter tool to update your manuscript."
+      output.puts "\nFor more information please go to this page: #{helpurl}"
   	end
   else
     logstring = 'n-a'

--- a/filearchive_postprocessing.rb
+++ b/filearchive_postprocessing.rb
@@ -135,7 +135,7 @@ def writeVersionErrfile(htmlmaker_js_version_test, errfile, helpurl, logkey='')
   if htmlmaker_js_version_test == false
   	File.open(errfile, 'w') do |output|
   		output.puts "This document was styled using the old Macmillan style-template."
-  		output.puts "\nThe bookmaker toolchain has been updated, to generate good PDF’s and ePubs you must attach the latest template, and add Section Start styles to your document as needed."
+  		output.puts "\nThe bookmaker toolchain has been updated: to generate valid PDF and ePub output you must attach the latest style-template, and add Section Start styles to your document as needed."
   		output.puts "\nFor more information please go to this page: #{helpurl}"
   	end
   else

--- a/filearchive_postprocessing.rb
+++ b/filearchive_postprocessing.rb
@@ -11,6 +11,13 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 # Find supplemental titlepages
 finalimagedir = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "images")
 
+required_version_for_jsconvert = '4.7.0'
+
+helpurl = 'https://confluence.macmillan.com/display/PWG/Stylecheck+Help'
+
+# full path to the version error file
+version_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "TEMPLATE_VERSION_ERROR.txt")
+
 
 # ---------------------- METHODS
 
@@ -48,6 +55,97 @@ ensure
 Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
+# If a version error file exists, delete it
+## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+def checkErrorFile(file, logkey='')
+	if File.file?(file)
+		Mcmlln::Tools.deleteFile(file)
+	else
+		logstring = 'n-a'
+	end
+rescue => logstring
+ensure
+	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def readOutputHtml(logkey='')
+	filecontents = File.read(Bkmkr::Paths.outputtmp_html)
+	return filecontents
+rescue => logstring
+  return ''
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def checkHTMLforTemplateVersion(filecontents)
+  version = filecontents.scan(/<meta name="templateversion"/)
+  unless version.nil? or version.empty? or !version
+    templateversion = filecontents.match(/(<meta name="templateversion" content=")(.*)("\/>)/)[2]
+  else
+    templateversion = ''
+  end
+  return templateversion
+rescue => logstring
+  return ''
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+# returns true if v1 is nil, empty, or >= v2. Otherwise returns false
+def versionCompare(v1, v2, logkey='')
+  if v1.nil?
+    logstring = "template_version is nil; htmlmaker_preprocessing.rb may have crashed?"
+    return false
+  elsif v1.empty?
+    logstring = "template_version is empty; input file is html or this is a non-Macmillan bookmaker instance"
+    return false
+  elsif v1.match(/[^\d.]/) || v2.match(/[^\d.]/)
+    logstring = "template_version string includes nondigit chars: returning false."
+    return false
+  elsif v1 == v2
+    logstring = "template_version meets requirements for jsconvert"
+    return true
+  else
+    v1long = v1.split('.').length
+    v2long = v2.split('.').length
+    maxlength = v1long > v2long ? v1long : v2long
+    0.upto(maxlength-1) { |n|
+      puts "n is #{n}"
+      v1split = v1.split('.')[n].to_i
+      v2split = v2.split('.')[n].to_i
+      if v1split > v2split
+        logstring = "template_version meets requirements for jsconvert"
+        return true
+      elsif v1split < v2split
+        logstring = "template_version is older than required version for jsconvert: returning false, xsl conversion"
+        return false
+      elsif n == maxlength-1 && v1split == v2split
+        logstring = "template_version meets requirements for jsconvert"
+        return true
+      end
+    }
+  end
+rescue => logstring
+  return true
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def writeVersionErrfile(htmlmaker_js_version_test, errfile, helpurl, logkey='')
+  if htmlmaker_js_version_test == false
+  	File.open(errfile, 'w') do |output|
+  		output.puts "This document was styled using the old Macmillan style-template."
+  		output.puts "\nThe bookmaker toolchain has been updated, to generate good PDF’s and ePubs you must attach the latest template, and add Section Start styles to your document as needed."
+  		output.puts "\nFor more information please go to this page: #{helpurl}"
+  	end
+  else
+    logstring = 'n-a'
+  end
+rescue => logstring
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
 
 # ---------------------- PROCESSES
 
@@ -56,6 +154,27 @@ archivePodTitlePage(finalimagedir, 'archive_podtitlepage')
 
 # move epubtitlepage to archival dir, if it exists & is not already there
 archiveEpubTitlePage(finalimagedir, 'archive_epubtitlepage')
+
+# # # moving version template alert stiuff here from htmlmaker_postprocessing.rb, b/c that script pre-exists final_dir
+# delete version error file if it exists
+checkErrorFile(version_error, 'delete_version_errfile')
+
+# get template_version value from json logfile (local_log_hash is a hash of the json logfile, read in at the beginning of each script)
+if local_log_hash.key?('htmlmaker_preprocessing.rb')
+  template_version = local_log_hash['htmlmaker_preprocessing.rb']['template_version']
+else
+  filecontents = readOutputHtml('read_output_html')
+  # scan for version in outputtmp.html (will return '' if no templateversion value found in hrml):
+  template_version = checkHTMLforTemplateVersion(filecontents, 'check_htlm_for_template_version')
+end
+
+# versionCompare returns false if:
+#   template_version <= required_version_for_jsconvert, template_version has any non-digit chars (besides '.'), is nil, or is empty
+htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
+@log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
+
+# if version error, write file for user (and email workflows?)
+writeVersionErrfile(htmlmaker_js_version_test, version_error, helpurl, 'write_errfile_as_needed')
 
 
 # ---------------------- LOGGING

--- a/getTemplateVersion.py
+++ b/getTemplateVersion.py
@@ -31,7 +31,7 @@ def check_xml_for_version(xmlstring, custom_doc_property_name):
 			template_version = child[0].text
 
 	if not template_version:
-		template_version = 'not_found'
+		template_version = ''
 
 	return template_version
 
@@ -39,7 +39,7 @@ def check_xml_for_version(xmlstring, custom_doc_property_name):
 xmlstring = read_xml_in_docx(docxfile, xmlfile)
 
 if not xmlstring:
-	template_version = 'not_found'
+	template_version = ''
 else:
 	template_version = check_xml_for_version(xmlstring, custom_doc_property_name)
 

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -64,7 +64,7 @@ fs.readFile(file, function editContent(err, contents) {
   $("p[class^='CopyrightText']:not(:has(a.spanISBNisbn))").each(function () {
       var mypattern1 = new RegExp( "978(\\D?\\d?){10}", "g");
       var result1 = mypattern1.test($( this ).text());
-  console.log(result1);
+      // console.log(result1);
       if ( result1 === true ) {
         var newtext = $( this ).text().replace(/(978(\D?\d?){10})/g, '<span class="spanISBNisbn">$1</span>');
         $(this).empty();
@@ -110,7 +110,6 @@ fs.readFile(file, function editContent(err, contents) {
     $(this).after(match[4]);
   });
 
-<<<<<<< HEAD
   // remove Section-Blank-Page sections
   $("section.blankpage").remove();
 
@@ -169,7 +168,7 @@ fs.readFile(file, function editContent(err, contents) {
     $(this).empty();
     $(this).append(myText);
   });
-=======
+
   function replaceHyphenatedStrings() {
     // Next we'll add some special handling for
     // long strings connected by hyphens.
@@ -261,7 +260,6 @@ fs.readFile(file, function editContent(err, contents) {
   };
 
   replaceHyphenatedStrings();
->>>>>>> d64613d937f5cf433a95c7acaae914fa1fbb6b98
 
   var output = $.html();
     fs.writeFile(file, output, function(err) {

--- a/htmlmaker_postprocessing.js
+++ b/htmlmaker_postprocessing.js
@@ -7,7 +7,7 @@ var pisbn = process.argv[5];
 var imprint = process.argv[6];
 var publisher = process.argv[7];
 
-fs.readFile(file, function editContent (err, contents) {
+fs.readFile(file, function editContent(err, contents) {
   $ = cheerio.load(contents, {
           xmlMode: true
         });
@@ -22,6 +22,10 @@ fs.readFile(file, function editContent (err, contents) {
       });
     });
   }
+
+  // add missing class names to inline tags that were converted from direct formatting
+  $("strong:not(.spanboldfacecharactersbf)").addClass("spanboldfacecharactersbf");
+  $("em:not(.spanitaliccharactersital)").addClass("spanitaliccharactersital");
 
   // merge contiguous small caps char styles
   $("p[class^='ChapOpeningText']").each(function (i) {
@@ -106,6 +110,7 @@ fs.readFile(file, function editContent (err, contents) {
     $(this).after(match[4]);
   });
 
+<<<<<<< HEAD
   // remove Section-Blank-Page sections
   $("section.blankpage").remove();
 
@@ -164,6 +169,99 @@ fs.readFile(file, function editContent (err, contents) {
     $(this).empty();
     $(this).append(myText);
   });
+=======
+  function replaceHyphenatedStrings() {
+    // Next we'll add some special handling for
+    // long strings connected by hyphens.
+    // Note that if the link replacements from the function above
+    // do not occur before this function, then hyphens within link
+    // text WILL NOT be spaced. (However, link href attributes will
+    // always be left alone.)
+
+    // First we need to set a counter and create an empty hash to work with.
+    var counter = 1;
+    var hashReplacements = {};
+
+    // Now we'll loop through every non-ISBN paragraph
+    $('p:contains("-"):not(:has(span.spanISBNisbn))').each(function (){
+      var para_txt = $(this).text();
+      var myhtml = $(this).html();
+      var myID = $(this).attr("id");
+      // Check to see if the paragraph contains any long strings
+      var testLongString = /((\S+-){4,})/g;
+      var result = testLongString.test(para_txt);
+      if (result === true) {
+        // Make sure the paragraph has an ID
+        if (myID === undefined) {
+          var newID = function () {
+            // Math.random should be unique because of its seeding algorithm.
+            // Convert it to base 36 (numbers + letters), and grab the first 9 characters
+            // after the decimal.
+            return '_' + Math.random().toString(36).substr(2, 9);
+          };
+          $(this).attr("id", newID);
+        }
+        // Replace hyphens in any child elements within the para
+       $(this).find("*").each(function () {
+          $(this).html($(this).html().replace(/-/g,"<span class='longhyphenhelper' style='font-size: 2pt; vertical-align:top;'> </span>-<span class='longhyphenhelper' style='font-size: 2pt; vertical-align:top;'> </span>"));
+        });
+        // now remove any instances of those spans that are enclosed in a hyperlinkspan. Have to do this in two steps; previously using a 'not' selector,
+        //  but the 'not' was not accounting for nested spans with hyperlink spans at different depths.
+        $(this).find(".spanhyperlinkurl").each(function () {
+           $(this).find(".longhyphenhelper").remove();
+        });
+        // Now we'll work with the raw top-level text.
+        // We want to make sure we aren't accidentally grabbing any child element
+        // attributes or other bits that shouldn't be changed.
+        var rawtext = $(this).contents().filter(function(){
+          return this.nodeType == 3 && this.nodeValue.match(/((\S+-){2,})/);
+        });
+        if (rawtext.length) {
+          // Now we'll loop through the child text and filter for just the hyphenated strings
+          rawtext.each(function() {
+            var currentString = this.nodeValue;
+            // We're matching shorter chunks this time, since a longer string
+            // could potentially be split up by a nested inline tag
+            var testShortString = /((\S+-\S*){2,})/g;
+            var patternMatches = [];
+            patternMatches = currentString.match(testShortString);
+            var parentid = $(this).parent().attr("id");
+            if (patternMatches) {
+              for (i = 0; i < patternMatches.length; i++) {
+                // For each hyphenated text string we find,
+                // we'll add the parent para id, the source string text, and our new markup to a hash.
+                var oldString = patternMatches[i];
+                // adding the vertical-align, otherwise for some reason the 2pt space disrupts vertical line-spacing.
+                var newString = patternMatches[i].replace(/-/g, "<span class='longhyphenhelper' style='font-size: 2pt; vertical-align:top;'> </span>-<span class='longhyphenhelper' style='font-size: 2pt; vertical-align:top;'> </span>");
+                // Wrap the hyphanted strings in a span for future potential targetting
+                newString = "<span class='longstring'>" + newString + "</span>";
+                hashReplacements[counter] = [];
+                hashReplacements[counter].push(parentid);
+                hashReplacements[counter].push(oldString);
+                hashReplacements[counter].push(newString);
+                counter = counter + 1;
+              }
+            }
+          });
+        }
+      }
+    });
+
+    // Now we loop through that hash and do the text replacements
+    // by targeting just the paragraph in which the strings occur
+    Object.keys(hashReplacements).forEach(function (key) {
+      var value = hashReplacements[key];
+      var selection = value[0];
+      var searchString = value[1];
+      var replacementString = value[2];
+      var oldHTML = $('p#' + selection).html();
+      var newHTML = $('p#' + selection).html().replace(searchString, replacementString);
+      $('p#' + selection).html(newHTML);
+    });
+  };
+
+  replaceHyphenatedStrings();
+>>>>>>> d64613d937f5cf433a95c7acaae914fa1fbb6b98
 
   var output = $.html();
     fs.writeFile(file, output, function(err) {

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -10,8 +10,27 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
 htmlmakerpostprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "htmlmaker_postprocessing.js")
 
+required_version_for_jsconvert = '4.7.0'
+
+helpurl = 'https://confluence.macmillan.com/display/PWG/Stylecheck+Help'
+
+# full path to the version error file
+version_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "TEMPLATE_VERSION_ERROR.txt")
 
 # ---------------------- METHODS
+
+# If a version error file exists, delete it
+## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+def checkErrorFile(file, logkey='')
+	if File.file?(file)
+		Mcmlln::Tools.deleteFile(file)
+	else
+		logstring = 'n-a'
+	end
+rescue => logstring
+ensure
+	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
 
 ## wrapping Bkmkr::Tools.runnode in a new method for this script; to return a result for json_logfile
 def localRunNode(jsfile, args, logkey='')
@@ -48,8 +67,79 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
+def checkHTMLforTemplateVersion(filecontents)
+  version = filecontents.scan(/<meta name="templateversion"/)
+  unless version.nil? or version.empty? or !version
+    templateversion = filecontents.match(/(<meta name="templateversion" content=")(.*)("\/>)/)[2]
+  else
+    templateversion = ''
+  end
+  return templateversion
+rescue => logstring
+  return ''
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+# returns true if v1 is nil, empty, or >= v2. Otherwise returns false
+def versionCompare(v1, v2, logkey='')
+  if v1.nil?
+    logstring = "template_version is nil; htmlmaker_preprocessing.rb may have crashed?"
+    return false
+  elsif v1.empty?
+    logstring = "template_version is empty; input file is html or this is a non-Macmillan bookmaker instance"
+    return false
+  elsif v1.match(/[^\d.]/) || v2.match(/[^\d.]/)
+    logstring = "template_version string includes nondigit chars: returning false."
+    return false
+  elsif v1 == v2
+    logstring = "template_version meets requirements for jsconvert"
+    return true
+  else
+    v1long = v1.split('.').length
+    v2long = v2.split('.').length
+    maxlength = v1long > v2long ? v1long : v2long
+    0.upto(maxlength-1) { |n|
+      puts "n is #{n}"
+      v1split = v1.split('.')[n].to_i
+      v2split = v2.split('.')[n].to_i
+      if v1split > v2split
+        logstring = "template_version meets requirements for jsconvert"
+        return true
+      elsif v1split < v2split
+        logstring = "template_version is older than required version for jsconvert: returning false, xsl conversion"
+        return false
+      elsif n == maxlength-1 && v1split == v2split
+        logstring = "template_version meets requirements for jsconvert"
+        return true
+      end
+    }
+  end
+rescue => logstring
+  return true
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
+def writeVersionErrfile(htmlmaker_js_version_test, errfile, helpurl, logkey='')
+  if htmlmaker_js_version_test == false
+  	File.open(errfile, 'w') do |output|
+  		output.puts "This document was styled using the old Macmillan style-template."
+  		output.puts "\nThe bookmaker toolchain has been updated, to generate good PDF’s and ePubs you must attach the latest template, and add Section Start styles to your document as needed."
+  		output.puts "\nFor more information please go to this page: #{helpurl}"
+  	end
+  else
+    logstring = 'n-a'
+  end
+rescue => logstring
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
 
 # ---------------------- PROCESSES
+
+# delete version error file if it exists
+checkErrorFile(version_error, 'delete_version_errfile')
 
 # run content conversions
 localRunNode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html, 'post-processing_js')
@@ -58,6 +148,22 @@ filecontents = readOutputHtml('read_output_html')
 filecontents = fixNoteCallouts(filecontents, 'fix_note_callouts')
 
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_html')
+
+# get template_version value from json logfile (local_log_hash is a hash of the json logfile, read in at the beginning of each script)
+if local_log_hash.key?('htmlmaker_preprocessing.rb')
+  template_version = local_log_hash['htmlmaker_preprocessing.rb']['template_version']
+else
+  # scan for version in outputtmp.html (will return '' if no templateversion value found in hrml):
+  template_version = checkHTMLforTemplateVersion(filecontents, 'check_htlm_for_template_version')
+end
+
+# versionCompare returns false if:
+#   template_version <= required_version_for_jsconvert, template_version has any non-digit chars (besides '.'), is nil, or is empty
+htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
+@log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
+
+# if version error, write file for user (and email workflows?)
+writeVersionErrfile(htmlmaker_js_version_test, version_error, helpurl, 'write_errfile_as_needed')
 
 # ---------------------- LOGGING
 

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -10,27 +10,27 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
 htmlmakerpostprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "htmlmaker_postprocessing.js")
 
-required_version_for_jsconvert = '4.7.0'
-
-helpurl = 'https://confluence.macmillan.com/display/PWG/Stylecheck+Help'
-
-# full path to the version error file
-version_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "TEMPLATE_VERSION_ERROR.txt")
+# required_version_for_jsconvert = '4.7.0'
+#
+# helpurl = 'https://confluence.macmillan.com/display/PWG/Stylecheck+Help'
+#
+# # full path to the version error file
+# version_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "TEMPLATE_VERSION_ERROR.txt")
 
 # ---------------------- METHODS
 
-# If a version error file exists, delete it
-## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
-def checkErrorFile(file, logkey='')
-	if File.file?(file)
-		Mcmlln::Tools.deleteFile(file)
-	else
-		logstring = 'n-a'
-	end
-rescue => logstring
-ensure
-	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
+# # If a version error file exists, delete it
+# ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
+# def checkErrorFile(file, logkey='')
+# 	if File.file?(file)
+# 		Mcmlln::Tools.deleteFile(file)
+# 	else
+# 		logstring = 'n-a'
+# 	end
+# rescue => logstring
+# ensure
+# 	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+# end
 
 ## wrapping Bkmkr::Tools.runnode in a new method for this script; to return a result for json_logfile
 def localRunNode(jsfile, args, logkey='')
@@ -138,8 +138,8 @@ end
 
 # ---------------------- PROCESSES
 
-# delete version error file if it exists
-checkErrorFile(version_error, 'delete_version_errfile')
+# # delete version error file if it exists
+# checkErrorFile(version_error, 'delete_version_errfile')
 
 # run content conversions
 localRunNode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html, 'post-processing_js')
@@ -148,22 +148,22 @@ filecontents = readOutputHtml('read_output_html')
 filecontents = fixNoteCallouts(filecontents, 'fix_note_callouts')
 
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_html')
-
-# get template_version value from json logfile (local_log_hash is a hash of the json logfile, read in at the beginning of each script)
-if local_log_hash.key?('htmlmaker_preprocessing.rb')
-  template_version = local_log_hash['htmlmaker_preprocessing.rb']['template_version']
-else
-  # scan for version in outputtmp.html (will return '' if no templateversion value found in hrml):
-  template_version = checkHTMLforTemplateVersion(filecontents, 'check_htlm_for_template_version')
-end
-
-# versionCompare returns false if:
-#   template_version <= required_version_for_jsconvert, template_version has any non-digit chars (besides '.'), is nil, or is empty
-htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
-@log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
-
-# if version error, write file for user (and email workflows?)
-writeVersionErrfile(htmlmaker_js_version_test, version_error, helpurl, 'write_errfile_as_needed')
+#
+# # get template_version value from json logfile (local_log_hash is a hash of the json logfile, read in at the beginning of each script)
+# if local_log_hash.key?('htmlmaker_preprocessing.rb')
+#   template_version = local_log_hash['htmlmaker_preprocessing.rb']['template_version']
+# else
+#   # scan for version in outputtmp.html (will return '' if no templateversion value found in hrml):
+#   template_version = checkHTMLforTemplateVersion(filecontents, 'check_htlm_for_template_version')
+# end
+#
+# # versionCompare returns false if:
+# #   template_version <= required_version_for_jsconvert, template_version has any non-digit chars (besides '.'), is nil, or is empty
+# htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
+# @log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
+#
+# # if version error, write file for user (and email workflows?)
+# writeVersionErrfile(htmlmaker_js_version_test, version_error, helpurl, 'write_errfile_as_needed')
 
 # ---------------------- LOGGING
 

--- a/htmlmaker_postprocessing.rb
+++ b/htmlmaker_postprocessing.rb
@@ -10,28 +10,8 @@ local_log_hash, @log_hash = Bkmkr::Paths.setLocalLoghash
 
 htmlmakerpostprocessingjs = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "htmlmaker_postprocessing.js")
 
-# required_version_for_jsconvert = '4.7.0'
-#
-# helpurl = 'https://confluence.macmillan.com/display/PWG/Stylecheck+Help'
-#
-# # full path to the version error file
-# version_error = File.join(Bkmkr::Paths.done_dir, Metadata.pisbn, "TEMPLATE_VERSION_ERROR.txt")
 
 # ---------------------- METHODS
-
-# # If a version error file exists, delete it
-# ## wrapping a Mcmlln::Tools method in a new method for this script; to return a result for json_logfile
-# def checkErrorFile(file, logkey='')
-# 	if File.file?(file)
-# 		Mcmlln::Tools.deleteFile(file)
-# 	else
-# 		logstring = 'n-a'
-# 	end
-# rescue => logstring
-# ensure
-# 	Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-# end
-
 ## wrapping Bkmkr::Tools.runnode in a new method for this script; to return a result for json_logfile
 def localRunNode(jsfile, args, logkey='')
 	Bkmkr::Tools.runnode(jsfile, args)
@@ -67,79 +47,8 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def checkHTMLforTemplateVersion(filecontents)
-  version = filecontents.scan(/<meta name="templateversion"/)
-  unless version.nil? or version.empty? or !version
-    templateversion = filecontents.match(/(<meta name="templateversion" content=")(.*)("\/>)/)[2]
-  else
-    templateversion = ''
-  end
-  return templateversion
-rescue => logstring
-  return ''
-ensure
-  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
-
-# returns true if v1 is nil, empty, or >= v2. Otherwise returns false
-def versionCompare(v1, v2, logkey='')
-  if v1.nil?
-    logstring = "template_version is nil; htmlmaker_preprocessing.rb may have crashed?"
-    return false
-  elsif v1.empty?
-    logstring = "template_version is empty; input file is html or this is a non-Macmillan bookmaker instance"
-    return false
-  elsif v1.match(/[^\d.]/) || v2.match(/[^\d.]/)
-    logstring = "template_version string includes nondigit chars: returning false."
-    return false
-  elsif v1 == v2
-    logstring = "template_version meets requirements for jsconvert"
-    return true
-  else
-    v1long = v1.split('.').length
-    v2long = v2.split('.').length
-    maxlength = v1long > v2long ? v1long : v2long
-    0.upto(maxlength-1) { |n|
-      puts "n is #{n}"
-      v1split = v1.split('.')[n].to_i
-      v2split = v2.split('.')[n].to_i
-      if v1split > v2split
-        logstring = "template_version meets requirements for jsconvert"
-        return true
-      elsif v1split < v2split
-        logstring = "template_version is older than required version for jsconvert: returning false, xsl conversion"
-        return false
-      elsif n == maxlength-1 && v1split == v2split
-        logstring = "template_version meets requirements for jsconvert"
-        return true
-      end
-    }
-  end
-rescue => logstring
-  return true
-ensure
-  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
-
-def writeVersionErrfile(htmlmaker_js_version_test, errfile, helpurl, logkey='')
-  if htmlmaker_js_version_test == false
-  	File.open(errfile, 'w') do |output|
-  		output.puts "This document was styled using the old Macmillan style-template."
-  		output.puts "\nThe bookmaker toolchain has been updated, to generate good PDF’s and ePubs you must attach the latest template, and add Section Start styles to your document as needed."
-  		output.puts "\nFor more information please go to this page: #{helpurl}"
-  	end
-  else
-    logstring = 'n-a'
-  end
-rescue => logstring
-ensure
-  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
-end
 
 # ---------------------- PROCESSES
-
-# # delete version error file if it exists
-# checkErrorFile(version_error, 'delete_version_errfile')
 
 # run content conversions
 localRunNode(htmlmakerpostprocessingjs, Bkmkr::Paths.outputtmp_html, 'post-processing_js')
@@ -148,22 +57,6 @@ filecontents = readOutputHtml('read_output_html')
 filecontents = fixNoteCallouts(filecontents, 'fix_note_callouts')
 
 overwriteFile(Bkmkr::Paths.outputtmp_html, filecontents, 'overwrite_html')
-#
-# # get template_version value from json logfile (local_log_hash is a hash of the json logfile, read in at the beginning of each script)
-# if local_log_hash.key?('htmlmaker_preprocessing.rb')
-#   template_version = local_log_hash['htmlmaker_preprocessing.rb']['template_version']
-# else
-#   # scan for version in outputtmp.html (will return '' if no templateversion value found in hrml):
-#   template_version = checkHTMLforTemplateVersion(filecontents, 'check_htlm_for_template_version')
-# end
-#
-# # versionCompare returns false if:
-# #   template_version <= required_version_for_jsconvert, template_version has any non-digit chars (besides '.'), is nil, or is empty
-# htmlmaker_js_version_test = versionCompare(template_version, required_version_for_jsconvert, 'version_compare')
-# @log_hash['htmlmaker_js_version_test'] = htmlmaker_js_version_test
-#
-# # if version error, write file for user (and email workflows?)
-# writeVersionErrfile(htmlmaker_js_version_test, version_error, helpurl, 'write_errfile_as_needed')
 
 # ---------------------- LOGGING
 

--- a/htmlmaker_preprocessing.rb
+++ b/htmlmaker_preprocessing.rb
@@ -74,7 +74,6 @@ convertDocToDocxPSscript(filetype, 'convert_doc_to_docx')
 template_version = checktemplate_version(filetype, get_template_version_py, 'check_docx_template_version')
 @log_hash['template_version'] = template_version
 
-@log_hash['hi'] = 'hi'
 # run replacements on any w:sym elements in the word xml:
 # Right now, just to catch a copyright symbol variant, but for additional replacements, just run the method again with codes
 #   wsymcode values can be found in the xml (value of 'w:char attribute for the w:sym'), here is a large table of these codes:

--- a/htmlmaker_preprocessing.rb
+++ b/htmlmaker_preprocessing.rb
@@ -79,8 +79,8 @@ template_version = checktemplate_version(filetype, get_template_version_py, 'che
 #   wsymcode values can be found in the xml (value of 'w:char attribute for the w:sym'), here is a large table of these codes:
 #     https://gist.github.com/ptsefton/1ce30879e9cfef289356
 #   replacement code should be unicode for desired replacement symbol: http://www.fileformat.info/info/unicode/char/search.htm
-#     the desired format is the 'Python source code' version, sans the preceding 'u'
-replace_wsym(filetype, replace_wsym_py, 'F0D3', '\u00A9', 'replace_w:sym_copyright_symbol')
+#     the desired format is the 'C/C++/Java source code' including the doublequotes
+replace_wsym(filetype, replace_wsym_py, 'F0D3', "\u00A9", 'replace_w:sym_copyright_symbol')
 
 
 # Create a temp JSON file

--- a/htmlmaker_preprocessing.rb
+++ b/htmlmaker_preprocessing.rb
@@ -13,6 +13,8 @@ configfile = File.join(Bkmkr::Paths.project_tmp_dir, "config.json")
 
 get_template_version_py = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "getTemplateVersion.py")
 
+replace_wsym_py = File.join(Bkmkr::Paths.scripts_dir, "bookmaker_addons", "replace_wsym.py")
+
 # ---------------------- METHODS
 
 def convertDocToDocxPSscript(filetype, logkey='')
@@ -42,6 +44,20 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
+def replace_wsym(filetype, replace_wsym_py, wsymcode, replacementcode, logkey='')
+  unless filetype == "html"
+    # the replace_wsym_py script checks document.xml without unzipping the .docx. If w:sym with wsymcode is found,
+    #   the w:sym element is replaced with with the decoded replacementcode in the xml, the new xml is overwritten to file,
+    #   the original file is backed up, and the .docx is overwritten with edits.
+    logstring = Bkmkr::Tools.runpython(replace_wsym_py, "#{Bkmkr::Paths.project_docx_file} #{wsymcode} #{replacementcode}")
+  else
+    logstring = 'input file is html, skipping'
+  end
+rescue => logstring
+ensure
+  Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
+end
+
 def writeConfigJson(hash, json, logkey='')
   Mcmlln::Tools.write_json(hash, json)
 rescue => logstring
@@ -57,6 +73,16 @@ convertDocToDocxPSscript(filetype, 'convert_doc_to_docx')
 # get document version template number if it exists
 template_version = checktemplate_version(filetype, get_template_version_py, 'check_docx_template_version')
 @log_hash['template_version'] = template_version
+
+@log_hash['hi'] = 'hi'
+# run replacements on any w:sym elements in the word xml:
+# Right now, just to catch a copyright symbol variant, but for additional replacements, just run the method again with codes
+#   wsymcode values can be found in the xml (value of 'w:char attribute for the w:sym'), here is a large table of these codes:
+#     https://gist.github.com/ptsefton/1ce30879e9cfef289356
+#   replacement code should be unicode for desired replacement symbol: http://www.fileformat.info/info/unicode/char/search.htm
+#     the desired format is the 'Python source code' version, sans the preceding 'u'
+replace_wsym(filetype, replace_wsym_py, 'F0D3', '\u00A9', 'replace_w:sym_copyright_symbol')
+
 
 # Create a temp JSON file
 datahash = {}

--- a/htmlmaker_preprocessing.rb
+++ b/htmlmaker_preprocessing.rb
@@ -49,7 +49,7 @@ def replace_wsym(filetype, replace_wsym_py, wsymcode, replacementcode, logkey=''
     # the replace_wsym_py script checks document.xml without unzipping the .docx. If w:sym with wsymcode is found,
     #   the w:sym element is replaced with with the decoded replacementcode in the xml, the new xml is overwritten to file,
     #   the original file is backed up, and the .docx is overwritten with edits.
-    logstring = Bkmkr::Tools.runpython(replace_wsym_py, "#{Bkmkr::Paths.project_docx_file} #{wsymcode} #{replacementcode}")
+    logstring = Bkmkr::Tools.runpython(replace_wsym_py, "#{Bkmkr::Paths.project_docx_file} #{wsymcode} #{replacementcode}").strip()
   else
     logstring = 'input file is html, skipping'
   end

--- a/metadata_preprocessing.rb
+++ b/metadata_preprocessing.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'htmlentities'
+require 'nokogiri'
 
 unless (ENV['TRAVIS_TEST']) == 'true'
   require_relative '../bookmaker/core/header.rb'
@@ -157,16 +158,26 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def setAuthorInfo(myhash, html_contents, logkey='')
+def setAuthorInfo(myhash, htmlfile, logkey='')
+  # get the page tree via nokogiri
+  page = Nokogiri::HTML(open(htmlfile))
   # get meta info from html if it exists
-  metabookauthor = html_contents.match(/(<meta name="author" content=")(.*?)("\/>)/i)
-  # Finding author name(s)
-  if !metabookauthor.nil?
-    authorname = HTMLEntities.new.decode(metabookauthor[2]).encode('utf-8')
-  elsif myhash.nil? or myhash.empty? or !myhash or myhash['book'].nil? or myhash['book'].empty? or !myhash['book'] or myhash['book']['WORK_COVERAUTHOR'].nil? or myhash['book']['WORK_COVERAUTHOR'].empty? or !myhash['book']['WORK_COVERAUTHOR']
-    authorname = html_contents.scan(/<p[^>]*?class="TitlepageAuthorNameau".*?>(.*?)<.*?>/).join(", ")
+  metabookauthor = page.xpath('//meta[@name="author"]/@content')
+  # Finding book title
+  if !metabookauthor.empty?
+    puts "Getting book AUTHOR from meta element"
+    authorname = HTMLEntities.new.decode(metabookauthor).encode('utf-8')
+  elsif myhash.nil? or myhash.empty? or !myhash or myhash['book'].nil? or myhash['book'].empty? or !myhash['book'] or myhash["book"]["WORK_COVERTITLE"].nil? or myhash["book"]["WORK_COVERTITLE"].empty? or !myhash["book"]["WORK_COVERTITLE"]
+    puts "Getting book AUTHOR from titlepage"
+    names = []
+    authorname = page.css(".TitlepageAuthorNameau")
+    authorname.each do |t|
+      names << t.text
+    end
+    authorname = names.join(", ")
     authorname = HTMLEntities.new.decode(authorname).encode('utf-8')
   else
+    puts "Getting book AUTHOR from config"
     authorname = myhash['book']['WORK_COVERAUTHOR']
     authorname = authorname.encode('utf-8')
   end
@@ -177,16 +188,26 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def setBookTitle(myhash, html_contents, logkey='')
+def setBookTitle(myhash, htmlfile, logkey='')
+  # get the page tree via nokogiri
+  page = Nokogiri::HTML(open(htmlfile))
   # get meta info from html if it exists
-  metabooktitle = html_contents.match(/(<meta name="title" content=")(.*?)("\/>)/i)
+  metabooktitle = page.xpath('//meta[@name="title"]/@content')
   # Finding book title
-  if !metabooktitle.nil?
-    booktitle = HTMLEntities.new.decode(metabooktitle[2]).encode('utf-8')
+  if !metabooktitle.empty?
+    puts "Getting book TITLE from meta element"
+    booktitle = HTMLEntities.new.decode(metabooktitle).encode('utf-8')
   elsif myhash.nil? or myhash.empty? or !myhash or myhash['book'].nil? or myhash['book'].empty? or !myhash['book'] or myhash["book"]["WORK_COVERTITLE"].nil? or myhash["book"]["WORK_COVERTITLE"].empty? or !myhash["book"]["WORK_COVERTITLE"]
-    booktitle = html_contents.scan(/<h1[^<]*?class="TitlepageBookTitletit".*?>(.*?)<.*?>/).join(", ")
+    puts "Getting book TITLE from titlepage"
+    titles = []
+    booktitle = page.css(".TitlepageBookTitletit")
+    booktitle.each do |t|
+      titles << t.text
+    end
+    booktitle = titles.join(" ")
     booktitle = HTMLEntities.new.decode(booktitle).encode('utf-8')
   else
+    puts "Getting book TITLE from config"
     booktitle = myhash["book"]["WORK_COVERTITLE"]
     booktitle = booktitle.encode('utf-8')
   end
@@ -197,16 +218,26 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def setBookSubtitle(myhash, html_contents, logkey='')
+def setBookSubtitle(myhash, htmlfile, logkey='')
+  # get the page tree via nokogiri
+  page = Nokogiri::HTML(open(htmlfile))
   # get meta info from html if it exists
-  metabooksubtitle = html_contents.match(/(<meta name="subtitle" content=")(.*?)("\/>)/i)
-  # Finding book subtitle
-  if !metabooksubtitle.nil?
-    booksubtitle = HTMLEntities.new.decode(metabooksubtitle[2]).encode('utf-8')
-  elsif myhash.nil? or myhash.empty? or !myhash or myhash['book'].nil? or myhash['book'].empty? or !myhash['book'] or myhash["book"]["WORK_SUBTITLE"].nil? or myhash["book"]["WORK_SUBTITLE"].empty? or !myhash["book"]["WORK_SUBTITLE"]
-    booksubtitle = html_contents.scan(/<p[^<]*?class="TitlepageBookSubtitlestit".*?>(.*?)<.*?>/).join(", ")
+  metabooksubtitle = page.xpath('//meta[@name="subtitle"]/@content')
+  # Finding book title
+  if !metabooksubtitle.empty?
+    puts "Getting book SUBTITLE from meta element"
+    booksubtitle = HTMLEntities.new.decode(metabooksubtitle).encode('utf-8')
+  elsif myhash.nil? or myhash.empty? or !myhash or myhash['book'].nil? or myhash['book'].empty? or !myhash['book'] or myhash["book"]["WORK_COVERTITLE"].nil? or myhash["book"]["WORK_COVERTITLE"].empty? or !myhash["book"]["WORK_COVERTITLE"]
+    puts "Getting book SUBTITLE from titlepage"
+    subtitles = []
+    booksubtitle = page.css(".TitlepageBookSubtitlestit")
+    booksubtitle.each do |t|
+      subtitles << t.text
+    end
+    booksubtitle = subtitles.join(" ")
     booksubtitle = HTMLEntities.new.decode(booksubtitle).encode('utf-8')
   else
+    puts "Getting book SUBTITLE from config"
     booksubtitle = myhash["book"]["WORK_SUBTITLE"]
     booksubtitle = booksubtitle.encode('utf-8')
   end
@@ -241,17 +272,20 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def setImprint(myhash, project_dir, imprint_json, logkey='')
+def setImprint(myhash, htmlfile, project_dir, imprint_json, logkey='')
+  # get the page tree via nokogiri
+  page = Nokogiri::HTML(open(htmlfile))
   # get meta info from html if it exists
-  metaimprint = File.read(Bkmkr::Paths.outputtmp_html).match(/(<meta name="imprint" content=")(.*?)("\/>)/i)
+  metaimprint = page.xpath('//meta[@name="imprint"]/@content')
   # Finding imprint name
-  # imprint = File.read(Bkmkr::Paths.outputtmp_html).scan(/<p class="TitlepageImprintLineimp">.*?</).to_s.gsub(/\["<p class=\\"TitlepageImprintLineimp\\">/,"").gsub(/"\]/,"").gsub(/</,"")
-  # Manually populating for now, until we get the DB set up
-  if !metaimprint.nil?
-    imprint = HTMLEntities.new.decode(metaimprint[2])
+  if !metaimprint.empty?
+    puts "Getting book IMPRINT from meta element"
+    imprint = HTMLEntities.new.decode(metaimprint)
   elsif myhash.nil? or myhash.empty? or !myhash or myhash['book'].nil? or myhash['book'].empty? or !myhash['book'] or myhash["book"]["IMPRINT_DESC"].nil? or myhash["book"]["IMPRINT_DESC"].empty? or !myhash["book"]["IMPRINT_DESC"]
+    puts "Getting book IMPRINT from config json"
     imprint = getImprint(project_dir, imprint_json, 'get_imprint_from_json')
   else
+    puts "Getting book IMPRINT from database"
     imprint = myhash["book"]["IMPRINT_DESC"]
     imprint = imprint.encode('utf-8')
   end
@@ -262,13 +296,17 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def setPublisher(myhash, imprint, logkey='')
+def setPublisher(myhash, htmlfile, imprint, logkey='')
+  # get the page tree via nokogiri
+  page = Nokogiri::HTML(open(htmlfile))
   # get meta info from html if it exists
-  metapublisher = File.read(Bkmkr::Paths.outputtmp_html).match(/(<meta name="publisher" content=")(.*?)("\/>)/i)
+  metapublisher = page.xpath('//meta[@name="publisher"]/@content')
   # Finding publisher
-  if !metapublisher.nil?
-    publisher = HTMLEntities.new.decode(metapublisher[2])
+  if !metapublisher.empty?
+    puts "Getting book PUBLISHER from meta element"
+    publisher = HTMLEntities.new.decode(metapublisher)
   else
+    puts "Getting book PUBLISHER from imprint"
     publisher = imprint
   end
   return publisher
@@ -278,15 +316,17 @@ ensure
   Mcmlln::Tools.logtoJson(@log_hash, logkey, logstring)
 end
 
-def setTemplate(myhash, logkey='')
+def setTemplate(myhash, htmlfile, logkey='')
+  # get the page tree via nokogiri
+  page = Nokogiri::HTML(open(htmlfile))
   # get meta info from html if it exists
-  metatemplate = File.read(Bkmkr::Paths.outputtmp_html).match(/(<meta name="template" content=")(.*?)("\/>)/i)
-  if !metatemplate.nil?
-    template = HTMLEntities.new.decode(metatemplate[2])
-    logstring = "Design template: #{template}"
+  metatemplate = page.xpath('//meta[@name="template"]/@content')
+  if !metatemplate.empty?
+    template = HTMLEntities.new.decode(metatemplate)
+    logstring = "#{template}"
   else
     template = ""
-    logstring = "Design template: default"
+    logstring = "default"
   end
   puts logstring
   return metatemplate, template
@@ -463,22 +503,22 @@ html_contents = readFile(Bkmkr::Paths.outputtmp_html, 'get_outputtmp_html_conten
 
 # Setting metadata vars for config.json:
 # Prioritize metainfo from html, then edition info from biblio, then scan html for tagged data
-authorname = setAuthorInfo(myhash, html_contents, 'set_author_info')
+authorname = setAuthorInfo(myhash, Bkmkr::Paths.outputtmp_html, 'set_author_info')
 @log_hash['author_name'] = authorname
 
-booktitle = setBookTitle(myhash, html_contents, 'set_book_title')
+booktitle = setBookTitle(myhash, Bkmkr::Paths.outputtmp_html, 'set_book_title')
 @log_hash['book_title'] = booktitle
 
-booksubtitle = setBookSubtitle(myhash, html_contents, 'set_book_subtitle')
+booksubtitle = setBookSubtitle(myhash, Bkmkr::Paths.outputtmp_html, 'set_book_subtitle')
 @log_hash['book_subtitle'] = booksubtitle
 
-imprint = setImprint(myhash, project_dir, imprint_json, 'set_imprint')
+imprint = setImprint(myhash, Bkmkr::Paths.outputtmp_html, project_dir, imprint_json, 'set_imprint')
 @log_hash['imprint'] = imprint
 
-publisher = setPublisher(myhash, imprint, 'set_publisher')
+publisher = setPublisher(myhash, Bkmkr::Paths.outputtmp_html, imprint, 'set_publisher')
 @log_hash['publisher'] = publisher
 
-metatemplate, template = setTemplate(myhash, 'set_template')
+metatemplate, template = setTemplate(myhash, Bkmkr::Paths.outputtmp_html, 'set_design_template')
 
 
 # print and epub css files

--- a/replace_wsym.py
+++ b/replace_wsym.py
@@ -9,8 +9,6 @@ import traceback
 docxfile = sys.argv[1]
 charcode = sys.argv[2]
 replacementstring = sys.argv[3].decode("utf-8")
-# rstring = "\u00A9"    # debug
-# charcode = 'F0D3'     # debug
 
 # load modules from sectionstart scripts_dir
 import imp

--- a/replace_wsym.py
+++ b/replace_wsym.py
@@ -8,7 +8,8 @@ import traceback
 
 docxfile = sys.argv[1]
 charcode = sys.argv[2]
-replacementstring = sys.argv[3].decode("utf-8")
+replacement = sys.argv[3]
+replacementstring = replacement.decode("utf-8")
 
 # load modules from sectionstart scripts_dir
 import imp
@@ -91,7 +92,7 @@ try:
             copyfile(docxfile, pre_replacement_docx)
         # zip up edited xml & replace input file
         zipDOCX.zipDOCX(unzip_dir, docxfile)
-        print "Found %s '%s'(s), replaced %s of them with %s" % (wsym_count, charcode, wsyms_replaced, replacementstring)
+        print "Found {} '{}'(s), replaced {}, with {}".format(wsym_count, charcode, wsyms_replaced, replacement)
     else:
         print "No '%s'(s) found, no replacements made" % charcode
 

--- a/replace_wsym.py
+++ b/replace_wsym.py
@@ -1,0 +1,97 @@
+import sys
+import os
+import zipfile
+from shutil import copyfile
+# make sure to install lxml: sudo pip install lxml
+from lxml import etree
+
+docxfile = sys.argv[1]
+charcode = sys.argv[2]
+replacementstring = sys.argv[3].decode("utf-8")
+# rstring = "\u00A9"    # debug
+# charcode = 'F0D3'     # debug
+
+# load modules from sectionstart scripts_dir
+import imp
+zipDOCXpath = os.path.join(sys.path[0],'..','sectionstart_converter','xml_docx_stylechecks','shared_utils','zipDOCX.py')
+unzipDOCXpath = os.path.join(sys.path[0],'..','sectionstart_converter','xml_docx_stylechecks','shared_utils','unzipDOCX.py')
+os_utilspath = os.path.join(sys.path[0],'..','sectionstart_converter','xml_docx_stylechecks','shared_utils','os_utils.py')
+zipDOCX = imp.load_source('zipDOCX', zipDOCXpath)
+unzipDOCX = imp.load_source('unzipDOCX', unzipDOCXpath)
+os_utils = imp.load_source('os_utils', os_utilspath)
+
+# local vars
+doc_xmlfile = 'word/document.xml'
+searchstring = ".//w:sym[@w:font='Symbol'][@w:char='%s']" % charcode
+# Word namespace vars
+wnamespace = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+# w14namespace = 'http://schemas.microsoft.com/office/word/2010/wordml'
+# vtnamespace = "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+# mcnamespace = "http://schemas.openxmlformats.org/markup-compatibility/2006"
+# xmlnamespace = "http://www.w3.org/XML/1998/namespace"
+# wordnamespaces = {'w': wnamespace, 'w14': w14namespace, 'vt': vtnamespace, 'mc': mcnamespace}
+
+
+# # # # # # # # # # METHODS
+
+def check_xml_for_wsym(docx, xmlfile, searchstring):
+    wsym_check = False
+    # read in the dpcument without unzipping
+    document = zipfile.ZipFile(docx, 'a')
+    docxml_root = etree.fromstring(document.read(xmlfile))
+    # scan for symbol in question
+    if docxml_root.findall(searchstring, {'w': wnamespace}):
+        wsym_check = True
+    # print wsym_check  debug
+    return wsym_check
+
+
+def replace_wsym(unzip_dir, doc_xmlfile, searchstring, replace_string):
+    # get xml root for queries
+    docxml = os.path.join(unzip_dir, doc_xmlfile)
+    docxml_tree = etree.parse(docxml)
+    docxml_root = docxml_tree.getroot()
+
+    # capture all w:sym instances, set counts
+    wsyms = docxml_root.findall(searchstring, {'w': wnamespace})
+    wsym_count = len(wsyms)
+    wsyms_replaced = 0
+    # print "found %s" % wsym_count # debug
+
+    # cycle through and replace w:sym with replacement text
+    for sym in wsyms:
+        # create a new w:t
+        new_text_element = etree.Element("{%s}t" % wnamespace)
+        new_text_element.text = replace_string
+        # insert new element with replacement text
+        sym.addnext(new_text_element)
+        # remove w:sym symbol
+        sym.getparent().remove(sym)
+        wsyms_replaced += 1
+
+    if wsyms_replaced > 0:
+        os_utils.writeXMLtoFile(docxml_root, docxml)
+
+    return wsym_count, wsyms_replaced
+
+
+# # # # # # # # # # RUN
+
+# check for existence of symbol without unzipping
+wsym_check = check_xml_for_wsym(docxfile, doc_xmlfile, searchstring)
+
+if wsym_check == True:
+    # at least one instance of the symbol exists. Unzip:
+    unzip_dir = os.path.join(os.path.dirname(docxfile),"%s_unzipped" % os.path.basename(docxfile))
+    unzipDOCX.unzipDOCX(docxfile, unzip_dir)
+    # replace symbol in xml, write edited xml out to document.xml
+    wsym_count, wsyms_replaced = replace_wsym(unzip_dir, doc_xmlfile, searchstring, replacementstring)
+    # make a backup copy of input file
+    pre_replacement_docx = os.path.join(os.path.dirname(docxfile),"%s_pre-sym-replacement%s" % (os.path.splitext(docxfile)[0],os.path.splitext(docxfile)[1]))
+    if not os.path.exists(pre_replacement_docx):
+        copyfile(docxfile, pre_replacement_docx)
+    # zip up edited xml & replace input file
+    zipDOCX.zipDOCX(unzip_dir, docxfile)
+    print "Found %s '%s'(s), replaced %s of them with %s" % (wsym_count, charcode, wsyms_replaced, replacementstring)
+else:
+    print "No '%s'(s) found, no replacements made" % charcode

--- a/replace_wsym.py
+++ b/replace_wsym.py
@@ -92,7 +92,7 @@ try:
             copyfile(docxfile, pre_replacement_docx)
         # zip up edited xml & replace input file
         zipDOCX.zipDOCX(unzip_dir, docxfile)
-        print "Found {} '{}'(s), replaced {}, with {}".format(wsym_count, charcode, wsyms_replaced, replacement)
+        print "Found {} '{}'(s), replaced {}".format(wsym_count, charcode, wsyms_replaced)
     else:
         print "No '%s'(s) found, no replacements made" % charcode
 

--- a/unit_testing/unit_tests.rb
+++ b/unit_testing/unit_tests.rb
@@ -79,22 +79,24 @@ puts @@html_contents_fixed
 
 
   def testMetadataPreprocessing
-    # read the updated html
+    # read the updated html contents
+    # (no longer necessary for these tests, as the function being tested was updated to take a file as an argument..
+    #   but good to have as an example for future tests)
     html_contents_bad_tmp = self.class.getHTMLfileContents(@@test_html_bad_tmp)
     html_contents_good_tmp = self.class.getHTMLfileContents(@@test_html_good_tmp)
 
     ### Assertions:
     # method: setAuthorInfo
-    assert_equal(setAuthorInfo({}, html_contents_bad_tmp), "Alva Noë, Keenan Tester, Linda Tester")
-    assert_equal(setAuthorInfo({}, html_contents_good_tmp), "Alva Noë, Keenan Tester, Linda Tester")
+    assert_equal(setAuthorInfo({}, @@test_html_bad_tmp), "Alva Noë, Keenan Tester, Linda Tester")
+    assert_equal(setAuthorInfo({}, @@test_html_good_tmp), "Alva Noë, Keenan Tester, Linda Tester")
     assert_equal(setAuthorInfo({}, ''), "")
     # method: setBookSubtitle
-    assert_equal(setBookSubtitle({}, html_contents_bad_tmp), "Art and Human Nature, Or, How I Became an Artist")
-    assert_equal(setBookSubtitle({}, html_contents_good_tmp), "Art and Human Nature, Or, How I Became an Artist")
+    assert_equal(setBookSubtitle({}, @@test_html_bad_tmp), "Art and Human Nature Or, How I Became an Artist")
+    assert_equal(setBookSubtitle({}, @@test_html_good_tmp), "Art and Human Nature Or, How I Became an Artist")
     assert_equal(setBookSubtitle({}, ''), "")
     # method: setBookTitle
-    assert_equal(setBookTitle({}, html_contents_bad_tmp), "Strange Tools")
-    assert_equal(setBookTitle({}, html_contents_good_tmp), "Strange Tools")
+    assert_equal(setBookTitle({}, @@test_html_bad_tmp), "Strange Tools")
+    assert_equal(setBookTitle({}, @@test_html_good_tmp), "Strange Tools")
     assert_equal(setBookTitle({}, ''), "")
 
   end


### PR DESCRIPTION
Added a script to check and (if necessary) replace any copyright w:sym chars in the manuscript with python.  Set it to be called via htmlpreprocessing.rb

This is branched off of 'versionerr' branch in this repo, so [that PR](https://github.com/macmillanpublishers/bookmaker_addons/pull/181) should probably be reviewed before this one.

This has a companion PR with a very minor edit.

@lsquill , please review?